### PR TITLE
Implemented domain content

### DIFF
--- a/Command/GeneratePlatformDomainTypesCommand.php
+++ b/Command/GeneratePlatformDomainTypesCommand.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace BD\EzPlatformGraphQLBundle\Command;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\RepositoryDomainGenerator;
+use eZ\Publish\API\Repository\Repository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
+
+class GeneratePlatformDomainTypesCommand extends Command
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Repository
+     */
+    private $repository;
+
+    /**
+     * @var \BD\EzPlatformGraphQLBundle\DomainContent\RepositoryTypesGenerator
+     */
+    private $generator;
+
+    const TYPES_DIRECTORY = "src/AppBundle/Resources/config/graphql";
+
+    public function __construct(Repository $repository, RepositoryDomainGenerator $generator)
+    {
+        parent::__construct();
+        $this->repository = $repository;
+        $this->generator = $generator;
+    }
+
+    protected function configure()
+    {
+        $this->setName('bd:platform-graphql:generate-domain-schema');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $types = $this->generator->generateFromRepository($this->repository);
+
+        $fs = new Filesystem();
+        foreach ($types as $type => $definition) {
+            $typeFilePath = self::TYPES_DIRECTORY . "/$type.types.yml";
+            $fs->dumpFile(
+                $typeFilePath,
+                Yaml::dump([$type => $definition], 6)
+            );
+            $output->writeln("Written $typeFilePath");
+        }
+    }
+}

--- a/DependencyInjection/BDEzPlatformGraphQLExtension.php
+++ b/DependencyInjection/BDEzPlatformGraphQLExtension.php
@@ -24,5 +24,6 @@ class BDEzPlatformGraphQLExtension extends Extension
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+        $loader->load('domain_content.yml');
     }
 }

--- a/DomainContent/NameHelper.php
+++ b/DomainContent/NameHelper.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 23/09/2018
+ * Time: 23:05
+ */
+
+namespace BD\EzPlatformGraphQLBundle\DomainContent;
+
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+class NameHelper
+{
+    /**
+     * @var \Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
+     */
+    private $caseConverter;
+
+    public function __construct()
+    {
+        $this->caseConverter = new CamelCaseToSnakeCaseNameConverter(null, false);
+    }
+
+    public function domainContentCollectionField(ContentType $contentType)
+    {
+        return lcfirst($this->toCamelCase($contentType->identifier)) . 's';
+    }
+    public function domainContentName(ContentType $contentType)
+    {
+        return ucfirst($this->toCamelCase($contentType->identifier)) . 'Content';
+    }
+
+    public function domainContentField(ContentType $contentType)
+    {
+        return lcfirst($this->toCamelCase($contentType->identifier));
+    }
+
+    public function domainGroupName(ContentTypeGroup $contentTypeGroup)
+    {
+        return 'DomainGroup' . ucfirst($this->toCamelCase($contentTypeGroup->identifier));
+    }
+
+    public function domainGroupField(ContentTypeGroup $contentTypeGroup)
+    {
+        return lcfirst($this->toCamelCase($contentTypeGroup->identifier));
+    }
+
+    public function fieldDefinitionField(FieldDefinition $fieldDefinition)
+    {
+        return lcfirst($this->toCamelCase($fieldDefinition->identifier));
+    }
+
+    private function toCamelCase($string)
+    {
+        return $this->caseConverter->denormalize($string);
+    }
+}

--- a/DomainContent/RepositoryDomainGenerator.php
+++ b/DomainContent/RepositoryDomainGenerator.php
@@ -1,0 +1,80 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\DomainContent;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentTypeGroup\ContentTypeGroupSchemaWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType\ContentTypeSchemaWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\FieldDefinition\FieldDefinitionSchemaWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\SchemaWorker;
+use eZ\Publish\API\Repository\Repository;
+use InvalidArgumentException;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+class RepositoryDomainGenerator
+{
+    /**
+     * @var SchemaWorker[]
+     */
+    private $workers = [];
+    
+    public function __construct()
+    {
+    }
+
+    public function addWorker(SchemaWorker $worker)
+    {
+        $this->workers[] = $worker;
+    }
+
+    /**
+     * @param Repository $repository
+     *
+     * @return array
+     */
+    public function generateFromRepository(Repository $repository)
+    {
+        $contentTypeService = $repository->getContentTypeService();
+
+        $schema = [
+            'Domain' => [
+                'type' => 'object',
+                'config' => [
+                    'fields' => []
+                ]
+            ]
+        ];
+
+        foreach ($contentTypeService->loadContentTypeGroups() as $contentTypeGroup)
+        {
+            $this->runWorkers($schema, [
+                'ContentTypeGroup' => $contentTypeGroup
+            ]);
+
+            foreach ($contentTypeService->loadContentTypes($contentTypeGroup) as $contentType) {
+                $this->runWorkers($schema, [
+                    'ContentTypeGroup' => $contentTypeGroup,
+                    'ContentType' => $contentType
+                ]);
+
+                foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
+                    $this->runWorkers($schema, [
+                        'ContentTypeGroup' => $contentTypeGroup,
+                        'ContentType' => $contentType,
+                        'FieldDefinition' => $fieldDefinition
+                    ]);
+
+                }
+            }
+        }
+
+        return $schema;
+    }
+
+    private function runWorkers(&$schema, $args)
+    {
+        foreach ($this->workers as $worker) {
+            if ($worker->canWork($schema, $args)) {
+                $worker->work($schema, $args);
+            }
+        }
+    }
+}

--- a/DomainContent/SchemaWorker/BaseWorker.php
+++ b/DomainContent/SchemaWorker/BaseWorker.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 23/09/2018
+ * Time: 23:24
+ */
+
+namespace BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker;
+
+
+use BD\EzPlatformGraphQLBundle\DomainContent\NameHelper;
+
+class BaseWorker
+{
+    /**
+     * @var \BD\EzPlatformGraphQLBundle\DomainContent\NameHelper
+     */
+    private $nameHelper;
+
+    public function setNameHelper(NameHelper $nameHelper)
+    {
+        $this->nameHelper = $nameHelper;
+    }
+
+    protected function getNameHelper()
+    {
+        return $this->nameHelper;
+    }
+}

--- a/DomainContent/SchemaWorker/ContentType/AddDomainContentToDomainGroup.php
+++ b/DomainContent/SchemaWorker/ContentType/AddDomainContentToDomainGroup.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 23/09/2018
+ * Time: 23:24
+ */
+
+namespace BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\BaseWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\SchemaWorker;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
+
+class AddDomainContentToDomainGroup extends BaseWorker implements SchemaWorker
+{
+    public function work(array &$schema, array $args)
+    {
+        $contentType = $args['ContentType'];
+        $contentTypeGroup = $args['ContentTypeGroup'];
+        $descriptions = $contentType->getDescriptions();
+
+        $schema
+            [$this->getGroupName($contentTypeGroup)]
+            ['config']['fields']
+            [$this->getContentCollectionField($contentType)] = [
+                'type' => sprintf("[%s]", $this->getContentName($contentType)),
+                'description' => isset($descriptions['eng-GB']) ? $descriptions['eng-GB'] : 'No description available',
+                'resolve' => sprintf(
+                    '@=resolver("DomainContentItemsByTypeIdentifier", ["%s", args])',
+                    $contentType->identifier
+                ),
+                'args' => [
+                    'query' => [
+                        'type' => "ContentSearchQuery",
+                        'description' => "A Content query used to filter results"
+                    ],
+                ],
+            ];
+    }
+
+    public function canWork(array $schema, array $args)
+    {
+        return
+            isset($args['ContentType'])
+            && $args['ContentType'] instanceof ContentType
+            && isset($args['ContentTypeGroup'])
+            && $args['ContentTypeGroup'] instanceof ContentTypeGroup
+            && !$this->isFieldDefined($args['ContentTypeGroup'], $args['ContentType']);
+    }
+
+    /**
+     * @param $contentTypeGroup
+     * @return string
+     */
+    protected function getGroupName($contentTypeGroup): string
+    {
+        return $this->getNameHelper()->domainGroupName($contentTypeGroup);
+    }
+
+    /**
+     * @param $contentType
+     * @return string
+     */
+    protected function getContentCollectionField($contentType): string
+    {
+        return $this->getNameHelper()->domainContentCollectionField($contentType);
+    }
+
+    /**
+     * @param $contentType
+     * @return string
+     */
+    protected function getContentName($contentType): string
+    {
+        return $this->getNameHelper()->domainContentName($contentType);
+    }
+
+    private function isFieldDefined(ContentTypeGroup $contentTypeGroup, ContentType $contentType)
+    {
+        return isset(
+            $schema
+            [$this->getGroupName($contentTypeGroup)]
+            ['config']['fields']
+            [$this->getContentCollectionField($contentType)]
+        );
+    }
+}

--- a/DomainContent/SchemaWorker/ContentType/DefineDomainContent.php
+++ b/DomainContent/SchemaWorker/ContentType/DefineDomainContent.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 23/09/2018
+ * Time: 23:21
+ */
+
+namespace BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\BaseWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\SchemaWorker;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
+
+class DefineDomainContent extends BaseWorker implements SchemaWorker
+{
+    public function work(array &$schema, array $args)
+    {
+        $schema[$this->getDomainContentName($args['ContentType'])] = [
+            'type' => 'object',
+            'config' => [
+                'fields' => [
+                    '_content' => [
+                        'description' => 'Underlying content item',
+                        'type' => 'Content',
+                        'resolve' => '@=value["_content"].contentInfo'
+                    ],
+                    '_location' => [
+                        'description' => 'Main location',
+                        'type' => 'Location',
+                        'resolve' => '@=resolver("LocationById", [value["_content"].contentInfo.mainLocationId])'
+                    ],
+                    '_allLocations' => [
+                        'description' => 'All the locations',
+                        'type' => '[Location]',
+                        'resolve' => '@=resolver("LocationsByContentId", [value["_content"].id])'
+                    ]
+                ],
+                'interfaces' => ['DomainContent'],
+            ]
+        ];
+    }
+
+    public function canWork(array $schema, array $args)
+    {
+        return
+            isset($args['ContentType']) && $args['ContentType'] instanceof ContentType
+            && !isset($schema[$this->getDomainContentName($args['ContentType'])]);
+    }
+
+    /**
+     * @param $contentType
+     * @return string
+     */
+    protected function getDomainContentName(ContentType $contentType): string
+    {
+        return $this->getNameHelper()->domainContentName($contentType);
+    }
+}

--- a/DomainContent/SchemaWorker/ContentTypeGroup/AddDomainGroupToDomain.php
+++ b/DomainContent/SchemaWorker/ContentTypeGroup/AddDomainGroupToDomain.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 23/09/2018
+ * Time: 14:06
+ */
+
+namespace BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentTypeGroup;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\BaseWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\SchemaWorker;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
+use EzSystems\BehatBundle\Context\Object\ContentType;
+
+final class AddDomainGroupToDomain extends BaseWorker implements SchemaWorker
+{
+    public function work(array &$schema, array $args)
+    {
+        $contentTypeGroup = $args['ContentTypeGroup'];
+        $schema['Domain']['config']['fields'][$this->getGroupField($args['ContentTypeGroup'])] = [
+            'type' => $this->getGroupName($args['ContentTypeGroup']),
+            'description' => $contentTypeGroup->getDescription('eng-GB'),
+            'resolve' => [],
+        ];
+    }
+
+    public function canWork(array $schema, array $args)
+    {
+        return isset($args['ContentTypeGroup']) && $args['ContentTypeGroup'] instanceof ContentTypeGroup
+            && !isset($schema['Domain']['config']['fields'][$this->getGroupName($args['ContentTypeGroup'])]);
+    }
+
+    /**
+     * @param ContentTypeGroup $contentTypeGroup
+     * @return string
+     */
+    private function getGroupField(ContentTypeGroup $contentTypeGroup): string
+    {
+        return $this->getNameHelper()->domainGroupField($contentTypeGroup);
+    }
+
+    /**
+     * @param ContentTypeGroup $contentTypeGroup
+     * @return string
+     */
+    private function getGroupName(ContentTypeGroup $contentTypeGroup): string
+    {
+        return $this->getNameHelper()->domainGroupName($contentTypeGroup);
+    }
+}

--- a/DomainContent/SchemaWorker/ContentTypeGroup/DefineDomainGroup.php
+++ b/DomainContent/SchemaWorker/ContentTypeGroup/DefineDomainGroup.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 23/09/2018
+ * Time: 14:06
+ */
+
+namespace BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentTypeGroup;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\NameHelper;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\BaseWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\SchemaWorker;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
+
+class DefineDomainGroup extends BaseWorker implements SchemaWorker
+{
+    public function work(array &$schema, array $args)
+    {
+        $schema[$this->getGroupName($args['ContentTypeGroup'])] = [
+            'type' => 'object',
+            'config' => [
+                'fields' => []
+            ]
+        ];
+    }
+
+    public function canWork(array $schema, array $args)
+    {
+        return
+            isset($args['ContentTypeGroup']) && $args['ContentTypeGroup'] instanceof ContentTypeGroup
+            && !isset($schema[$this->getGroupName($args['ContentTypeGroup'])]);
+    }
+
+    /**
+     * @param ContentTypeGroup $contentTypeGroup
+     * @return string
+     */
+    protected function getGroupName(ContentTypeGroup $contentTypeGroup): string
+    {
+        return $this->getNameHelper()->domainGroupName($contentTypeGroup);
+    }
+}

--- a/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContent.php
+++ b/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContent.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 23/09/2018
+ * Time: 23:45
+ */
+
+namespace BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\FieldDefinition;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\BaseWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\SchemaWorker;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+
+class AddFieldDefinitionToDomainContent extends BaseWorker implements SchemaWorker
+{
+    /**
+     * FieldType <=> GraphQL type mapping.
+     * @todo Deduplicate, this comes from ContentResolver.
+     *
+     * @var array
+     */
+    private $typesMap = [
+        'ezauthor' => 'AuthorFieldValue',
+        'ezgmaplocation' => 'MapLocationFieldValue',
+        'ezimage' => 'ImageFieldValue',
+        'ezrichtext' => 'RichTextFieldValue',
+        'ezstring' => 'TextLineFieldValue',
+        'ezobjectrelation' => 'RelationFieldValue',
+        'ezobjectrelationlist' => 'RelationListFieldValue',
+    ];
+
+    public function work(array &$schema, array $args)
+    {
+        $fieldDefinition = $args['FieldDefinition'];
+        $fieldDefinitionField = $this->getFieldDefinitionField($args['FieldDefinition']);
+        $domainContentName = $this->getDomainContentName($args['ContentType']);
+
+        $schema[$domainContentName]['config']['fields'][$fieldDefinitionField] = [
+            'type' => $this->mapFieldTypeIdentifierToGraphQLType($fieldDefinition->fieldTypeIdentifier),
+            'resolve' => sprintf(
+                '@=resolver("DomainFieldValue", [value, "%s"])',
+                $fieldDefinition->identifier
+            ),
+        ];
+
+        $descriptions = $fieldDefinition->getDescriptions();
+        if (isset($descriptions['eng-GB'])) {
+            $fields[$fieldDefinitionField]['description'] = $descriptions['eng-GB'];
+        }
+    }
+
+    private function mapFieldTypeIdentifierToGraphQLType($fieldTypeIdentifier)
+    {
+        return isset($this->typesMap[$fieldTypeIdentifier]) ? $this->typesMap[$fieldTypeIdentifier] : 'GenericFieldValue';
+    }
+
+
+    public function canWork(array $schema, array $args)
+    {
+        return
+            isset($args['FieldDefinition'])
+            && $args['FieldDefinition'] instanceof FieldDefinition
+            & isset($args['ContentType'])
+            && $args['ContentType'] instanceof ContentType
+            && !$this->isFieldDefined($schema, $args);
+    }
+
+    /**
+     * @param ContentType $contentType
+     * @return string
+     */
+    protected function getDomainContentName(ContentType $contentType): string
+    {
+        return $this->getNameHelper()->domainContentName($contentType);
+    }
+
+    /**
+     * @param FieldDefinition $fieldDefinition
+     * @return string
+     */
+    protected function getFieldDefinitionField(FieldDefinition $fieldDefinition): string
+    {
+        return $this->getNameHelper()->fieldDefinitionField($fieldDefinition);
+    }
+
+    private function isFieldDefined($schema, $args)
+    {
+        return isset(
+            $schema[$this->getDomainContentName($args['ContentType'])]
+                   ['config']['fields']
+                   [$this->getFieldDefinitionField($args['FieldDefinition'])]);
+    }
+}

--- a/DomainContent/SchemaWorker/SchemaWorker.php
+++ b/DomainContent/SchemaWorker/SchemaWorker.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 23/09/2018
+ * Time: 23:54
+ */
+
+namespace BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker;
+
+interface SchemaWorker
+{
+    /**
+     * Does the work on $schema.
+     *
+     * @param array a reference to the schema
+     * @param array args
+     *
+     * @return void
+     */
+    public function work(array &$schema, array $args);
+
+    /**
+     * Tests the arguments and schema, and says if the worker can work on that state.
+     * It includes testing if the worker was already executed.
+     *
+     * @param array a reference to the schema
+     * @param array args
+     *
+     * @return bool
+     */
+    public function canWork(array $schema, array $args);
+}

--- a/GraphQL/Builder/DomainFieldBuilder.php
+++ b/GraphQL/Builder/DomainFieldBuilder.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace BD\EzPlatformGraphQLBundle\GraphQL\Builder;
+
+use Overblog\GraphQLBundle\Definition\Builder\MappingInterface;
+
+class DomainFieldBuilder implements MappingInterface
+{
+    const DOMAIN_SCHEMA_FILE = __DIR__. '/../../../../../src/AppBundle/Resources/config/graphql/Domain.types.yml';
+
+    public function toMappingDefinition(array $config)
+    {
+        $return = ['description' => 'Repository domain objects'];
+
+        if (file_exists(self::DOMAIN_SCHEMA_FILE)) {
+            $return['type'] = 'Domain';
+            $return['resolve'] = '[]';
+        } else {
+            $return['type'] = 'String';
+            $return['resolve'] = 'This resource is only available once the domain types have been generated.';
+        }
+
+        return $return;
+    }
+}

--- a/GraphQL/InputMapper/SearchQueryMapper.php
+++ b/GraphQL/InputMapper/SearchQueryMapper.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 21/09/2018
+ * Time: 16:50
+ */
+
+namespace BD\EzPlatformGraphQLBundle\GraphQL\InputMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use InvalidArgumentException;
+
+class SearchQueryMapper
+{
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Query
+     */
+    public function mapInputToQuery(array $inputArray)
+    {
+        $query = new Query();
+        $criteria = [];
+
+        if (isset($inputArray['ContentTypeIdentifier'])) {
+            $criteria[] = new Query\Criterion\ContentTypeIdentifier($inputArray['ContentTypeIdentifier']);
+        }
+
+        if (isset($inputArray['Text'])) {
+            foreach ($inputArray['Text'] as $text) {
+                $criteria[] = new Query\Criterion\FullText($text);
+            }
+        }
+
+        if (isset($inputArray['Field']))
+        {
+            $args = $inputArray['Field'];
+            foreach (['in', 'eq', 'like', 'contains', 'between', 'lt', 'lte', 'gt', 'gte'] as $opString) {
+                if (isset($args[$opString])) {
+                    $value = $args[$opString];
+                    $operator = constant('eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator::' . strtoupper($opString));
+                }
+            }
+
+            if (!isset($operator)) {
+                throw new InvalidArgumentException("Unspecified operator");
+            }
+
+            $criteria[] = new Query\Criterion\Field($args['target'], $operator, $value);
+        }
+
+        $criteria = array_merge($criteria, $this->mapDateMetadata($inputArray, 'Modified'));
+        $criteria = array_merge($criteria, $this->mapDateMetadata($inputArray, 'Created'));
+
+        if (count($criteria) === 0) {
+            return null;
+        }
+
+        if (count($criteria)) {
+            $query->filter = count($criteria) > 1 ? new Query\Criterion\LogicalAnd($criteria) : $criteria[0];
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param array $queryArg
+     * @param $dateMetadata
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\DateMetadata[]
+     */
+    private function mapDateMetadata(array $queryArg = [], $dateMetadata)
+    {
+        if (!isset($queryArg[$dateMetadata]) || !is_array($queryArg[$dateMetadata])) {
+            return [];
+        }
+
+        $targetMap = [
+            'Created' => Query\Criterion\DateMetadata::CREATED,
+            'Modified' => Query\Criterion\DateMetadata::MODIFIED,
+        ];
+
+        if (!isset($targetMap[$dateMetadata])) {
+            echo "Not a date metadata\n";
+            return [];
+        }
+
+        $dateOperatorsMap = [
+            'on' => Query\Criterion\Operator::EQ,
+            'before' => Query\Criterion\Operator::LTE,
+            'after' => Query\Criterion\Operator::GTE,
+        ];
+
+        $criteria = [];
+        foreach ($queryArg[$dateMetadata] as $operator => $dateString) {
+            if (!isset($dateOperatorsMap[$operator])) {
+                echo "Not a valid operator\n";
+                continue;
+            }
+
+            $criteria[] = new Query\Criterion\DateMetadata(
+                $targetMap[$dateMetadata],
+                $dateOperatorsMap[$operator],
+                strtotime($dateString)
+            );
+        }
+
+        return $criteria;
+    }
+}

--- a/GraphQL/InputMapper/SearchQueryMapper.php
+++ b/GraphQL/InputMapper/SearchQueryMapper.php
@@ -52,7 +52,7 @@ class SearchQueryMapper
         $criteria = array_merge($criteria, $this->mapDateMetadata($inputArray, 'Created'));
 
         if (count($criteria) === 0) {
-            return null;
+            return $query;
         }
 
         if (count($criteria)) {

--- a/GraphQL/Resolver/ContentResolver.php
+++ b/GraphQL/Resolver/ContentResolver.php
@@ -8,6 +8,7 @@ namespace BD\EzPlatformGraphQLBundle\GraphQL\Resolver;
 use BD\EzPlatformGraphQLBundle\GraphQL\Value\ContentFieldValue;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
@@ -87,7 +88,7 @@ class ContentResolver
         );
     }
 
-    public function findContentReverseRelations(ContentInfo $contentInfo, $version = null)
+    public function findContentReverseRelations(ContentInfo $contentInfo)
     {
         return $this->contentService->loadReverseRelations($contentInfo);
     }
@@ -110,11 +111,15 @@ class ContentResolver
 
     public function resolveContentByIdList(array $contentIdList)
     {
-        $searchResults = $this->searchService->findContentInfo(
-            new Query([
-                'filter' => new Query\Criterion\ContentId($contentIdList)
-            ])
-        );
+        try {
+            $searchResults = $this->searchService->findContentInfo(
+                new Query([
+                    'filter' => new Query\Criterion\ContentId($contentIdList)
+                ])
+            );
+        } catch (\Exception $e) {
+            return [];
+        }
 
         return array_map(
             function(SearchHit $searchHit) {

--- a/GraphQL/Resolver/DomainContentResolver.php
+++ b/GraphQL/Resolver/DomainContentResolver.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace BD\EzPlatformGraphQLBundle\GraphQL\Resolver;
+
+use BD\EzPlatformGraphQLBundle\GraphQL\InputMapper\SearchQueryMapper;
+use BD\EzPlatformGraphQLBundle\GraphQL\Value\ContentFieldValue;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Resolver\TypeResolver;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+class DomainContentResolver
+{
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService
+     */
+    private $contentService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\SearchService
+     */
+    private $searchService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService
+     */
+    private $contentTypeService;
+
+    /**
+     * @var \Overblog\GraphQLBundle\Resolver\TypeResolver
+     */
+    private $typeResolver;
+
+    /**
+     * @var SearchQueryMapper
+     */
+    private $queryMapper;
+
+    public function __construct(ContentService $contentService, SearchService $searchService, ContentTypeService $contentTypeService, TypeResolver $typeResolver, SearchQueryMapper $queryMapper)
+    {
+        $this->contentService = $contentService;
+        $this->searchService = $searchService;
+        $this->contentTypeService = $contentTypeService;
+        $this->typeResolver = $typeResolver;
+        $this->queryMapper = $queryMapper;
+    }
+
+    public function resolveDomainArticles()
+    {
+        return $this->resolveDomainContentItems('article');
+    }
+
+    public function resolveDomainBlogPosts()
+    {
+        return $this->resolveDomainContentItems('blog_post');
+    }
+
+    public function resolveDomainContentItems($contentTypeIdentifier, $query = null)
+    {
+        return array_map(
+            function (Content $content) {
+                return $content->contentInfo;
+            },
+            $this->findContentItemsByTypeIdentifier($contentTypeIdentifier, $query)
+        );
+    }
+
+    /**
+     * @param string $contentTypeIdentifier
+     *
+     * @param \Overblog\GraphQLBundle\Definition\Argument $args
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content[]
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    private function findContentItemsByTypeIdentifier($contentTypeIdentifier, Argument $args): array
+    {
+        $queryArg = $args['query'];
+        $queryArg['ContentTypeIdentifier'] = $contentTypeIdentifier;
+        $args['query'] = $queryArg;
+
+        $query = $this->queryMapper->mapInputToQuery($args['query']);
+        $searchResults = $this->searchService->findContent($query);
+
+        return array_map(
+            function (SearchHit $searchHit) {
+                return $searchHit->valueObject;
+            },
+            $searchResults->searchHits
+        );
+    }
+
+    public function resolveDomainSearch()
+    {
+        $searchResults = $this->searchService->findContentInfo(new Query([]));
+
+        return array_map(
+            function (SearchHit $searchHit) {
+                return $searchHit->valueObject;
+            },
+            $searchResults->searchHits
+        );
+    }
+
+    public function resolveDomainFieldValue($contentInfo, $fieldDefinitionIdentifier)
+    {
+        $content = $this->contentService->loadContent($contentInfo->id);
+
+        return new ContentFieldValue([
+            'contentTypeId' => $contentInfo->contentTypeId,
+            'fieldDefIdentifier' => $fieldDefinitionIdentifier,
+            'content' => $content,
+            'value' => $content->getFieldValue($fieldDefinitionIdentifier)
+        ]);
+    }
+
+    public function ResolveDomainContentType(ContentInfo $contentInfo)
+    {
+        static $contentTypesMap = [], $contentTypesLoadErrors = [];
+
+        if (!isset($contentTypesMap[$contentInfo->contentTypeId])) {
+            try {
+                $contentTypesMap[$contentInfo->contentTypeId] = $this->contentTypeService->loadContentType($contentInfo->contentTypeId);
+            } catch (\Exception $e) {
+                $contentTypesLoadErrors[$contentInfo->contentTypeId] = $e;
+                throw $e;
+            }
+        }
+
+        return $this->makeDomainContentTypeName($contentTypesMap[$contentInfo->contentTypeId]);
+    }
+
+    private function makeDomainContentTypeName(ContentType $contentType)
+    {
+        $converter = new CamelCaseToSnakeCaseNameConverter(null, false);
+
+        return $converter->denormalize($contentType->identifier) . 'Content';
+    }
+}

--- a/GraphQL/TypeDefinition/ContentTypeMapper.php
+++ b/GraphQL/TypeDefinition/ContentTypeMapper.php
@@ -1,0 +1,79 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\GraphQL\TypeDefinition;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+/**
+ * Maps a Platform Content Type to a Type Definition array.
+ */
+class ContentTypeMapper
+{
+    /**
+     * FieldType <=> GraphQL type mapping.
+     * @todo Deduplicate, this comes from ContentResolver.
+     *
+     * @var array
+     */
+    private $typesMap = [
+        'ezauthor' => 'AuthorFieldValue',
+        'ezgmaplocation' => 'MapLocationFieldValue',
+        'ezimage' => 'ImageFieldValue',
+        'ezrichtext' => 'RichTextFieldValue',
+        'ezstring' => 'TextLineFieldValue',
+        'ezobjectrelation' => 'RelationFieldValue',
+        'ezobjectrelationlist' => 'RelationListFieldValue',
+    ];
+
+    /**
+     * @return array A GraphQL type definition.
+     */
+    public function mapContentType(ContentType $contentType)
+    {
+        $fields = [
+            '_content' => [
+                'description' => 'Underlying content item',
+                'type' => 'Content',
+                'resolve' => '@=value["_content"].contentInfo'
+            ],
+            '_location' => [
+                'description' => 'Main location',
+                'type' => 'Location',
+                'resolve' => '@=resolver("LocationById", [value["_content"].contentInfo.mainLocationId])'
+            ],
+            '_allLocations' => [
+                'description' => 'All the locations',
+                'type' => '[Location]',
+                'resolve' => '@=resolver("LocationsByContentId", [value["_content"].id])'
+            ]
+        ];
+
+        foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
+            $descriptions = $fieldDefinition->getDescriptions();
+
+            $fields[$fieldDefinition->identifier] = [
+                'type' => $this->mapFieldTypeIdentifierToGraphQLType($fieldDefinition->fieldTypeIdentifier),
+                'resolve' => sprintf(
+                    '@=resolver("DomainFieldValue", [value, "%s"])',
+                    $fieldDefinition->identifier
+                ),
+            ];
+
+            if (isset($descriptions['eng-GB'])) {
+                $fields[$fieldDefinition->identifier]['description'] = $descriptions['eng-GB'];
+            }
+        }
+
+        return [
+            'type' => 'object',
+            'config' => [
+                'fields' => $fields,
+                'interfaces' => ['DomainContent'],
+            ]
+        ];
+    }
+
+    private function mapFieldTypeIdentifierToGraphQLType($fieldTypeIdentifier)
+    {
+        return isset($this->typesMap[$fieldTypeIdentifier]) ? $this->typesMap[$fieldTypeIdentifier] : 'GenericFieldValue';
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
 # eZ Platform GraphQL Bundle
 
-This Symfony bundle adds a GraphQL server to eZ Platform, the Open Source CMS.
+This Symfony bundle adds a GraphQL server to eZ Platform, the Open Source CMS. It exposes two endpoints.
 
-It relies on overblog/graphql-bundle.
+## The domain graph: `/graphql/domain`
+`https://<host>/graphql/domain`
+
+A graph of the repository's domain. It exposes the domain modelled using the repository,
+based on  content types groups, content types and fields definitions. Use it to implement
+apps or sites dedicated to a given repository structure.
+
+Example: an eZ Platform site.
+
+**Warning: this feature requires extra configuration steps. See the [Domain Schema documentation](doc/domain_schema.md).**
+
+## The repository graph: `/graphql/repository`
+`https://<host>/graphql/repository`
+
+A graph of the repository's Public API. It exposes value objects from the repository:
+content, location, field, url alias...
+It is recommended for admin like applications, not limited to a particular repository.
+
+Example: an eZ Platform Admin UI extension.
+
+[Repository schema documentation](doc/repository_schema.md)
 
 ## Installation
 
@@ -29,7 +49,15 @@ overblog_graphql:
     definitions:
         config_validation: %kernel.debug%
         schema:
-            query: Query
+            repository:
+                query: Query
+            domain:
+                query: Domain
+        builders:
+            field:
+                -
+                    alias: "Domain"
+                    class: "BD\\EzPlatformGraphQLBundle\\GraphQL\\Builder\\DomainFieldBuilder"
 ```
 
 Add the GraphQL server route to `app/config/routing.yml`:
@@ -58,7 +86,8 @@ case 'dev':
 Add the GraphiQL route to `app/config/routing_dev.yml`:
 ```yaml
 overblog_graphql_graphiql:
-    resource: "@OverblogGraphiQLBundle/Resources/config/routing/graphiql.yml"
+    resource: "@OverblogGraphiQLBundle/Resources/config/routing.xml"
 ```
 
-Go to http://<yourhost>/graphiql.
+Open `http://<yourhost>/graphiql/repository` or `http://<yourhost>/graphiql/domain`
+(`domain` has specific installation requirements, see the [domain Schema documentation](doc/domain_schema.md)).

--- a/Resources/config/domain_content.yml
+++ b/Resources/config/domain_content.yml
@@ -1,0 +1,30 @@
+services:
+    _defaults:
+        autoconfigure: true
+        autowire: true
+        public: false
+
+    BD\EzPlatformGraphQLBundle\DomainContent\RepositoryDomainGenerator:
+        calls:
+            - [addWorker, ['@BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentTypeGroup\DefineDomainGroup']]
+            - [addWorker, ['@BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentTypeGroup\AddDomainGroupToDomain']]
+            - [addWorker, ['@BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType\DefineDomainContent']]
+            - [addWorker, ['@BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType\AddDomainContentToDomainGroup']]
+            - [addWorker, ['@BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\FieldDefinition\AddFieldDefinitionToDomainContent']]
+
+    BD\EzPlatformGraphQLBundle\DomainContent\NameHelper: ~
+
+    _instanceof:
+        BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\BaseWorker:
+            calls:
+                - [setNameHelper, ['@BD\EzPlatformGraphQLBundle\DomainContent\NameHelper']]
+
+    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType\DefineDomainContent: ~
+
+    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType\AddDomainContentToDomainGroup: ~
+
+    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentTypeGroup\DefineDomainGroup: ~
+
+    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentTypeGroup\AddDomainGroupToDomain: ~
+
+    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\FieldDefinition\AddFieldDefinitionToDomainContent: ~

--- a/Resources/config/graphql/DomainContent.types.yml
+++ b/Resources/config/graphql/DomainContent.types.yml
@@ -1,0 +1,17 @@
+# PROTOTYPE
+# These types are meant to be generated based on the content model.
+
+DomainContent:
+    type: "interface"
+    config:
+        fields:
+            _content:
+                description: "Underlying content item"
+                type: "Content"
+            _location:
+                description: "The content's main location"
+                type: "Location"
+            _allLocations:
+                description: "All the content's locations"
+                type: "[Location]"
+        resolveType: "@=resolver('DomainContentType', [value])"

--- a/Resources/config/graphql/Query.types.yml
+++ b/Resources/config/graphql/Query.types.yml
@@ -68,24 +68,10 @@ Query:
                     groupIdentifier:
                         type: "String"
                 resolve: "@=resolver('ContentTypesFromGroup', [args])"
+
             searchContent:
                 type: "[Content]"
                 args:
                     query:
                         type: "ContentSearchQuery!"
                 resolve: "@=resolver('SearchContent', [args])"
-
-ContentSearchQuery:
-    type: "input-object"
-    config:
-        fields:
-            ContentTypeIdentifier:
-                type: "[String]"
-            ContentTypeId:
-                type: "[String]"
-            Text:
-                type: "[String]"
-            CreatedDate:
-                type: "[String]"
-            ModifiedDate:
-                type: "[String]"

--- a/Resources/config/graphql/Search.types.yml
+++ b/Resources/config/graphql/Search.types.yml
@@ -1,0 +1,84 @@
+ContentSearchQuery:
+    type: "input-object"
+    config:
+        fields:
+            ContentTypeIdentifier:
+                type: "[String]"
+                description: "Content type identifier filter"
+            ContentTypeId:
+                type: "[String]"
+                description: "Filter on content type id"
+            Text:
+                type: "[String]"
+                description: "Filter on any text from the content item"
+            Created:
+                type: "DateInput"
+                description: "Filter the date the content was initially created on"
+            Modified:
+                type: "DateInput"
+                description: "Filter on the date the content was last modified on"
+            ParentLocationId:
+                type: "[Int]"
+                description: "Filter content based on its parent location id"
+            Field:
+                type: "FieldCriterionInput"
+                description: "Field filter"
+
+FieldCriterionInput:
+     type: "input-object"
+     config:
+         fields:
+             target:
+                 type: "String"
+                 description: "A field definition identifier"
+             between:
+                 description: "Between two values"
+                 type: "[String]"
+             contains:
+                 description: "Contains the value"
+                 type: 'String'
+             in:
+                 description: "Equal to one of the given values"
+                 type: "[String]"
+             eq:
+                 description: "Equal to the value"
+                 type: "String"
+             gt:
+                 description: "Greater than the value"
+                 type: "String"
+             contains:
+                 description: "Contains than the value"
+                 type: "String"
+             gte:
+                 description: "Greater than or equal to the value"
+                 type: 'String'
+             lt:
+                 description: "Lesser than the value"
+                 type: 'String'
+             lte:
+                 description: "Lesser than or equal to the value"
+                 type: 'String'
+             like:
+                 description: "Like the value"
+                 type: 'String'
+
+DateInput:
+    type: "input-object"
+    config:
+        fields:
+            before:
+                description: "Before the given date or time."
+                type: "String"
+            after:
+                description: "After the given date or time."
+                type: "String"
+            on:
+                description: "On the given date or time."
+                type: "String"
+
+DateCriterionOperator:
+    type: "enum"
+    config:
+        values:
+            before: {}
+            after: {}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,15 @@
 services:
+    bd_ezplatform_graphql.command.generate_platform_domain_schema:
+        autoconfigure: true
+        autowire: true
+        class: BD\EzPlatformGraphQLBundle\Command\GeneratePlatformDomainTypesCommand
+        arguments:
+            - "@ezpublish.api.repository"
+        tags:
+            -  { name: console.command }
+
+    BD\EzPlatformGraphQLBundle\GraphQL\TypeDefinition\ContentTypeMapper: ~
+
     bd_ezplatform_graphql.graph.resolver.location:
         class: BD\EzPlatformGraphQLBundle\GraphQL\Resolver\LocationResolver
         arguments:
@@ -33,6 +44,21 @@ services:
             - "@ezpublish.twig.extension.field_rendering"
         tags:
             - { name: overblog_graphql.resolver, alias: "FieldValueToHtml", method: "resolveFieldValueToHtml" }
+
+    BD\EzPlatformGraphQLBundle\GraphQL\Resolver\DomainContentResolver:
+        arguments:
+            - "@ezpublish.api.service.content"
+            - "@ezpublish.api.service.search"
+            - "@ezpublish.api.service.content_type"
+            - "@overblog_graphql.type_resolver"
+            - '@BD\EzPlatformGraphQLBundle\GraphQL\InputMapper\SearchQueryMapper'
+
+        tags:
+            - { name: overblog_graphql.resolver, alias: "DomainArticles", method: "resolveDomainArticles" }
+            - { name: overblog_graphql.resolver, alias: "DomainBlogPosts", method: "resolveDomainBlogPosts" }
+            - { name: overblog_graphql.resolver, alias: "DomainContentItemsByTypeIdentifier", method: "resolveDomainContentItems" }
+            - { name: overblog_graphql.resolver, alias: "DomainFieldValue", method: "resolveDomainFieldValue" }
+            - { name: overblog_graphql.resolver, alias: "DomainContentType", method: "resolveDomainContentType" }
 
     bd_ezplatform_graphql.graph.resolver.user:
         class: BD\EzPlatformGraphQLBundle\GraphQL\Resolver\UserResolver

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -80,6 +80,7 @@ services:
         class: BD\EzPlatformGraphQLBundle\GraphQL\Resolver\SearchResolver
         arguments:
             - "@ezpublish.api.service.search"
+            - '@BD\EzPlatformGraphQLBundle\GraphQL\InputMapper\SearchQueryMapper'
         tags:
             - { name: overblog_graphql.resolver, alias: "SearchContent", method: "searchContent" }
 
@@ -112,3 +113,5 @@ services:
     BD\EzPlatformGraphQLBundle\GraphQL\Resolver\DateResolver:
         tags:
             - { name: overblog_graphql.resolver, alias: "DateTimeFormat", method: "resolveDateToFormat"}
+
+    BD\EzPlatformGraphQLBundle\GraphQL\InputMapper\SearchQueryMapper: ~

--- a/doc/content_schema.md
+++ b/doc/content_schema.md
@@ -1,0 +1,28 @@
+# The content schema
+
+This GraphQL schema exposes the eZ Platform Repository with a structure
+similar to that of the [Public API](https://doc.ezplatform.com/en/latest/api/public_php_api).
+It gives access to Content, Fields, Locations, Content types... It can be accessed through
+`https://<host>/graphql`, as well as `http://<host>/graphiql` if
+you have installed GraphiQL.
+
+## Examples
+
+### List content types and their fields
+```
+{
+  contentTypes
+  {
+    identifier
+    groups {
+      identifier
+    }
+    fieldDefinitions {
+      identifier
+      fieldTypeIdentifier
+    }
+  }
+}
+```
+
+### List

--- a/doc/domain_schema.md
+++ b/doc/domain_schema.md
@@ -1,0 +1,81 @@
+# The domain schema
+
+The domain content is the GraphQL schema representation of an eZ Platform content model.
+It can be accessed with the `/graphql/domain` endpoint. Its usage requires that the GraphQL model is generated for a given repository, as a set of configuration files in the project's app.
+
+The generated schema will list:
+- the content types groups
+- for each group the content types it contains
+- for each content type, its fields definitions, mapped to their Field Value Type
+
+Queries look like this:
+
+```
+{
+  content {
+    articles {
+      title { text }
+      body { html }
+      image {
+        name
+        variations(alias: large) { uri }
+      }
+    }
+    folders {
+      name { text }
+    }
+  }
+}
+```
+
+## Setting it up
+
+Run `php bin/console bd:platform-graphql:generate-domain-schema` from the root of your
+eZ Platform installation. It will go over your repository, and generate the matching
+types in `src/AppBundle/Resources/graphql/`.
+
+Open `<host>/graphiql/domain`. The content type groups, content types and their fields
+will be exposed as the schema.
+
+## Customizing the schema
+
+### Schema workers
+
+Schema workers are used by the Repository Domain Generator to generate the domain's schema.
+The generator iterates on objects from the repository, and passes on the loaded data and the schema.
+
+Example:
+
+The `DefineDomainContent` worker will, given a Content Type, define the matching Domain Content type.
+Another, `AddDomainContentToDomainGroup`, will add the same Domain Content to its Domain Group.
+
+#### Creating a custom worker
+
+A custom worker will be added to customize the schema based on the content model.
+The generator will iterate over a given set of objects from the repository (content type groups,
+content types...), and provide workers with those.
+
+A worker implements the `DomainSchema\SchemaWorker\SchemaWorker` interface. They implement two methods:
+
+- `work` will use the arguments to modify the schema.
+- `canWork` will test the schema and arguments, and say if the worker can run on this data.
+  It must be called before calling `work`.
+  **the method must also verify that the schema hasn't been worked on already**
+  (usually by testing the schema itself). Yes, it is a bit redundant.
+
+Both method receive as arguments a reference to the schema array, and an array of arguments.
+
+A custom worker must be passed to the `BD\EzPlatformGraphQLBundle\DomainContent\RepositoryDomainGenerator` service
+by means of a compiler pass that adds a call to `addWorker()`.
+
+### Data available to workers
+
+A worker that does something for each Content Type should test in `canWork()` if the `ContentType`
+argument is defined. What data is available depends on the iteration.
+
+| **Iteration**      | ContentTypeGroup | ContentType | FieldDefinition |
+| ------------------ | ---------------- | ----------- | --------------- |
+| Content Type Group | Yes              | No          | No              |
+| Content Type       | Yes              | Yes         | No              |
+| Field Definition   | Yes              | Yes         | Yes             |
+


### PR DESCRIPTION
Allows query of content using their identifier and fields directly. The content types groups are used as root, with the content types as leafs. It can be accessed at `/graphql/domain` and `/graphiql/domain`.

```
{
  content {
    articles {
      name: title { text }
    }
    folders(query: { Text: "HTML" }) {
      name { text }
    }
  }
  media {
    images {
      name { text }
      image {
        large_image: variations(identifier: "large") { uri }
        small_image: variations(identifier: "large") { uri }
      }
    }
  }
}
```

It relies on a Custom GraphQL types for ContentTypes of the Repository, such as `ArticleContent` or `BlogPostContent`. Those have GraphQL fields for values of their fields values, allowing very quick access to actual content items values: Those types also have a `_content` field that gives access to the underlying
content item.

The schema for those is generated using a Command script. When executed, it writes the schema to `src/AppBundle/Resources/config/graphql`.
### TODO
- [ ] Think about pluralization of content type identifiers (`blog_post` => `blog_posts`)
- [x] More generally, think about resources that must be exposed. The current resolver does a simple search by ContentType identifier, but we can expose any kind of route. Some configuration could do wonders here (an occasion to re-use QueryTypes maybe).
