### PR TITLE
Use dev-master while requiring package with composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It relies on overblog/graphql-bundle.
 Install the package and its dependencies using composer:
 
 ```
-composer require bdunogier/ezplatform-graphql-bundle
+composer require bdunogier/ezplatform-graphql-bundle:dev-master
 ```
 
 Add the bundles to `app/AppKernel.php`:


### PR DESCRIPTION
Needed because the package is not yet on packagist, otherwise, composer whines and is not happy ;)