### PR TITLE
Relay connections support

### DIFF
--- a/Command/GeneratePlatformSchemaCommand.php
+++ b/Command/GeneratePlatformSchemaCommand.php
@@ -26,7 +26,7 @@ class GeneratePlatformSchemaCommand extends Command
      */
     private $generator;
 
-    const TYPES_DIRECTORY = "src/AppBundle/Resources/config/graphql";
+    const TYPES_DIRECTORY = "app/config/graphql";
 
     public function __construct(Repository $repository, SchemaGenerator $generator)
     {

--- a/DependencyInjection/BDEzPlatformGraphQLExtension.php
+++ b/DependencyInjection/BDEzPlatformGraphQLExtension.php
@@ -16,7 +16,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class BDEzPlatformGraphQLExtension extends Extension implements PrependExtensionInterface
 {
-    const DOMAIN_SCHEMA_FILE = __DIR__. '/../../../../src/AppBundle/Resources/config/graphql/Domain.types.yml';
+    const DOMAIN_SCHEMA_FILE = __DIR__. '/../../../../app/config/graphql/Domain.types.yml';
 
     /**
      * {@inheritdoc}

--- a/DomainContent/NameHelper.php
+++ b/DomainContent/NameHelper.php
@@ -30,9 +30,15 @@ class NameHelper
     {
         return $this->pluralize(lcfirst($this->toCamelCase($contentType->identifier)));
     }
+
     public function domainContentName(ContentType $contentType)
     {
         return ucfirst($this->toCamelCase($contentType->identifier)) . 'Content';
+    }
+
+    public function domainContentConnection($contentType)
+    {
+        return ucfirst($this->toCamelCase($contentType->identifier)) . 'ContentConnection';
     }
 
     public function domainContentTypeName(ContentType $contentType)

--- a/DomainContent/SchemaWorker/ContentType/AddDomainContentToDomainGroup.php
+++ b/DomainContent/SchemaWorker/ContentType/AddDomainContentToDomainGroup.php
@@ -25,17 +25,20 @@ class AddDomainContentToDomainGroup extends BaseWorker implements SchemaWorker
             [$this->getGroupName($contentTypeGroup)]
             ['config']['fields']
             [$this->getContentCollectionField($contentType)] = [
-                'type' => sprintf("[%s]", $this->getContentName($contentType)),
-                // @todo Improve description to mention that it is a collection ?
+                'type' => $this->getNameHelper()->domainContentConnection($contentType),
                 'description' => isset($descriptions['eng-GB']) ? $descriptions['eng-GB'] : 'No description available',
                 'resolve' => sprintf(
                     '@=resolver("DomainContentItemsByTypeIdentifier", ["%s", args])',
                     $contentType->identifier
                 ),
+                'argsBuilder' => 'Relay::Connection',
                 'args' => [
                     'query' => [
                         'type' => "ContentSearchQuery",
                         'description' => "A Content query used to filter results"
+                    ],
+                    'sortBy' => [
+                        'type' => 'SortByOptions'
                     ],
                 ],
             ];
@@ -46,10 +49,11 @@ class AddDomainContentToDomainGroup extends BaseWorker implements SchemaWorker
             [$this->getContentField($contentType)] = [
                 'type' => $this->getContentName($contentType),
                 'description' => isset($descriptions['eng-GB']) ? $descriptions['eng-GB'] : 'No description available',
-                'resolve' => sprintf('@=resolver("DomainContentItem", [args, "%s"])', $contentType->identifier),
+                'resolve' => sprintf(
+                    '@=resolver("DomainContentItem", [args, "%s"])',
+                    $contentType->identifier
+                ),
                 'args' => [
-                    // @todo How do we constraint this so that it only takes an id of an item of that type ?
-                    // same approach than GlobalId ? (<type>-<id>)
                     'id' => [
                         'type' => 'Int',
                         'description' => sprintf('A %s content id', $contentType->identifier),

--- a/DomainContent/SchemaWorker/ContentType/DefineDomainContent.php
+++ b/DomainContent/SchemaWorker/ContentType/DefineDomainContent.php
@@ -23,7 +23,7 @@ class DefineDomainContent extends BaseWorker implements SchemaWorker
             'inherits' => ['AbstractDomainContent'],
             'config' => [
                 'fields' => [],
-                'interfaces' => ['DomainContent'],
+                'interfaces' => ['DomainContent', 'Node'],
             ]
         ];
 
@@ -34,6 +34,14 @@ class DefineDomainContent extends BaseWorker implements SchemaWorker
                 'interfaces' => ['DomainContentType'],
                 'fields' => []
             ],
+        ];
+
+        $schema[$this->getNameHelper()->domainContentConnection($contentType)] = [
+            'type' => 'relay-connection',
+            'config' => [
+                'nodeType' => $this->getDomainContentName($contentType),
+                'inherits' => ['DomainContentByIdentifierConnection'],
+            ]
         ];
     }
 

--- a/GraphQL/InputMapper/SearchQueryMapper.php
+++ b/GraphQL/InputMapper/SearchQueryMapper.php
@@ -14,11 +14,18 @@ use InvalidArgumentException;
 class SearchQueryMapper
 {
     /**
+     * @param array $inputArray
      * @return \eZ\Publish\API\Repository\Values\Content\Query
      */
     public function mapInputToQuery(array $inputArray)
     {
         $query = new Query();
+        if (isset($inputArray['offset'])) {
+            $query->offset = $inputArray['offset'];
+        }
+        if (isset($inputArray['limit'])) {
+            $query->limit = $inputArray['limit'];
+        }
         $criteria = [];
 
         if (isset($inputArray['ContentTypeIdentifier'])) {
@@ -57,6 +64,10 @@ class SearchQueryMapper
 
         if (count($criteria)) {
             $query->filter = count($criteria) > 1 ? new Query\Criterion\LogicalAnd($criteria) : $criteria[0];
+        }
+
+        if (isset($inputArray['sortBy'])) {
+            $query->sortClauses = [new $inputArray['sortBy']];
         }
 
         return $query;

--- a/GraphQL/Relay/DomainConnectionBuilder.php
+++ b/GraphQL/Relay/DomainConnectionBuilder.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bdunogier
+ * Date: 29/10/2018
+ * Time: 12:39
+ */
+
+namespace BD\EzPlatformGraphQLBundle\GraphQL\Relay;
+
+
+use Overblog\GraphQLBundle\Relay\Connection\Output\ConnectionBuilder;
+
+class DomainConnectionBuilder extends ConnectionBuilder
+{
+    const PREFIX = 'DomainContent:';
+}

--- a/GraphQL/Relay/NodeResolver.php
+++ b/GraphQL/Relay/NodeResolver.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace BD\EzPlatformGraphQLBundle\GraphQL\Relay;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\NameHelper;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use Overblog\GraphQLBundle\Relay\Node\GlobalId;
+use Overblog\GraphQLBundle\Resolver\TypeResolver;
+
+class NodeResolver
+{
+    /**
+     * @var ContentService
+     */
+    private $contentService;
+
+    /**
+     * @var TypeResolver
+     */
+    private $typeResolver;
+
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+    /**
+     * @var NameHelper
+     */
+    private $nameHelper;
+
+    public function __construct(ContentService $contentService, TypeResolver $typeResolver, ContentTypeService $contentTypeService, NameHelper $nameHelper)
+    {
+        $this->contentService = $contentService;
+        $this->typeResolver = $typeResolver;
+        $this->contentTypeService = $contentTypeService;
+        $this->nameHelper = $nameHelper;
+    }
+
+    /**
+     * @param $globalId
+     *
+     * @return null|\eZ\Publish\API\Repository\Values\Content\ContentInfo
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function resolveNode($globalId)
+    {
+        $params = GlobalId::fromGlobalId($globalId);
+
+        if (in_array($params['type'], ['Content', 'DomainContent'])) {
+            return $this->contentService->loadContentInfo($params['id']);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param $object
+     *
+     * @return \GraphQL\Type\Definition\Type
+     */
+    public function resolveType($object)
+    {
+        if ($object instanceof ContentInfo) {
+            return $this->typeResolver->resolve(
+                $this->nameHelper->domainContentName(
+                    $this->contentTypeService->loadContentType($object->contentTypeId)
+                )
+            );
+        }
+    }
+}

--- a/GraphQL/Relay/SearchResolver.php
+++ b/GraphQL/Relay/SearchResolver.php
@@ -1,0 +1,70 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\GraphQL\Relay;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
+use Overblog\GraphQLBundle\Relay\Connection\Output\ConnectionBuilder;
+
+class SearchResolver
+{
+    /**
+     * @var SearchService
+     */
+    private $searchService;
+
+    public function __construct(SearchService $searchService)
+    {
+        $this->searchService = $searchService;
+    }
+
+    /**
+     * @param $args
+     * @return Connection
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function searchContent($args)
+    {
+        $queryArg = $args['query'];
+
+        $query = new Query();
+        $criteria = [];
+
+        if (isset($queryArg['ContentTypeIdentifier'])) {
+            $criteria[] = new Query\Criterion\ContentTypeIdentifier($queryArg['ContentTypeIdentifier']);
+        }
+
+        if (isset($queryArg['Text'])) {
+            foreach ($queryArg['Text'] as $text) {
+                $criteria[] = new Query\Criterion\FullText($text);
+            }
+        }
+
+        if (count($criteria) === 0) {
+            return null;
+        }
+        $query->filter = count($criteria) > 1 ? new Query\Criterion\LogicalAnd($criteria) : $criteria[0];
+        $searchResult = $this->searchService->findContentInfo($query);
+
+        $contentItems = array_map(
+            function (SearchHit $hit) {
+                return $hit->valueObject;
+            },
+            $searchResult->searchHits
+        );
+
+        $connection = ConnectionBuilder::connectionFromArraySlice(
+            $contentItems,
+            $args,
+            [
+                'sliceStart' => 0,
+                'arrayLength' => $searchResult->totalCount,
+            ]
+        );
+        $connection->sliceSize = count($contentItems);
+
+        return $connection;
+    }
+}

--- a/GraphQL/Resolver/ImageFieldResolver.php
+++ b/GraphQL/Resolver/ImageFieldResolver.php
@@ -33,7 +33,34 @@ class ImageFieldResolver
         $this->variations = $variations;
     }
 
+    public function resolveImageVariations(ImageFieldValue $fieldValue, $args)
+    {
+        list($content, $field) = $this->getImageField($fieldValue);
+
+        $variations = [];
+        foreach ($args['identifier'] as $identifier) {
+            $versionInfo = $this->contentService->loadVersionInfo($content->contentInfo);
+            $variations[] = $this->variationHandler->getVariation($field, $versionInfo, $identifier);
+        }
+
+        return $variations;
+    }
+
     public function resolveImageVariation(ImageFieldValue $fieldValue, $args)
+    {
+        list($content, $field) = $this->getImageField($fieldValue);
+        $versionInfo = $this->contentService->loadVersionInfo($content->contentInfo);
+
+        return $this->variationHandler->getVariation($field, $versionInfo, $args['identifier']);
+    }
+
+    /**
+     * @param ImageFieldValue $fieldValue
+     * @return array
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    protected function getImageField(ImageFieldValue $fieldValue): array
     {
         $idArray = explode('-', $fieldValue->imageId);
         if (count($idArray) != 3) {
@@ -61,15 +88,6 @@ class ImageFieldResolver
             throw new UserError("Image file {$field->value->id} doesn't exist");
         }
 
-        $variations = [];
-        foreach ($args['identifier'] as $identifier) {
-            $variations[] = $this->variationHandler->getVariation(
-                $field,
-                $this->contentService->loadVersionInfo($content->contentInfo),
-                $identifier
-            );
-        }
-
-        return $variations;
+        return array($content, $field);
     }
 }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ php bin/console bd:platform-graphql:generate-domain-schema
 php bin/console cache:clear
 ```
 
-It will generate a lot of yaml files in `src/AppBundle/Resources/config/graphql`, based on your content types.
+It will generate a lot of yaml files in `app/config/graphql`, based on your content types.
 
 ### GraphiQL
 The graphical graphQL client, GraphiQL, must be installed separately if you want to use it.

--- a/Resources/config/domain_content.yml
+++ b/Resources/config/domain_content.yml
@@ -48,3 +48,5 @@ services:
     BD\EzPlatformGraphQLBundle\DomainContent\FieldValueBuilder\SelectionFieldValueBuilder:
         tags:
             - {name: ezplatform_graphql.field_value_builder, type: 'ezselection'}
+
+    BD\EzPlatformGraphQLBundle\Schema\ImagesVariationsBuilder: ~

--- a/Resources/config/graphql/Content.types.yml
+++ b/Resources/config/graphql/Content.types.yml
@@ -1,12 +1,13 @@
 Content:
     type: object
     config:
+        interfaces: [Node]
         description: "An eZ Platform repository ContentInfo."
         fields:
             id:
-                type: "Int!"
+                type: "ID!"
+                builder: Relay::GlobalId
                 description: "The Content item's unique ID."
-                resolve:
             contentTypeId:
                 type: "Int!"
                 description: "The Content Type ID of the Content item."
@@ -97,6 +98,7 @@ Content:
                 type: "[ContentRelation]"
                 description: "Relations to this Content"
                 resolve: "@=resolver('ContentReverseRelations', [value])"
+
 ContentRelation:
     type: "object"
     config:

--- a/Resources/config/graphql/DomainContent.types.yml
+++ b/Resources/config/graphql/DomainContent.types.yml
@@ -30,6 +30,8 @@ AbstractDomainContent:
             id:
                 type: "ID!"
                 builder: Relay::GlobalId
+                builderConfig:
+                    typeName: DomainContent
                 description: "The Content item's unique ID."
             _type:
                 description: "The item's Content type"
@@ -81,3 +83,14 @@ BaseDomainContentType:
             _info:
                 type: ContentType
                 resolve: "@=value"
+
+DomainContentByIdentifierConnection:
+    type: relay-connection
+    config:
+        connectionFields:
+            sliceSize:
+                type: Int!
+            orderBy:
+                # @todo make an enum or object
+                # @todo generate
+                type: String

--- a/Resources/config/graphql/Field.types.yml
+++ b/Resources/config/graphql/Field.types.yml
@@ -101,8 +101,15 @@ ImageFieldValue:
                 type: "[ImageVariation]"
                 args:
                     identifier:
-                        type: "[String]"
+                        type: "[ImageVariationIdentifier]!"
                         description: "One or more variation identifiers."
+                resolve: "@=resolver('ImageVariation', [value.value, args])"
+            variation:
+                type: ImageVariation
+                args:
+                    identifier:
+                        type: ImageVariationIdentifier!
+                        description: "A variation identifier."
                 resolve: "@=resolver('ImageVariation', [value.value, args])"
             html:
                 type: "String"

--- a/Resources/config/graphql/Platform.types.yml
+++ b/Resources/config/graphql/Platform.types.yml
@@ -6,3 +6,8 @@ Platform:
                 type: Repository
                 resolve: { }
                 description: "eZ Platform repository API"
+            node:
+                builder: Relay::Node
+                builderConfig:
+                    nodeInterfaceType: Node
+                    idFetcher: '@=resolver("node", [value])'

--- a/Resources/config/graphql/Repository.types.yml
+++ b/Resources/config/graphql/Repository.types.yml
@@ -15,7 +15,7 @@ Repository:
                 args:
                     id:
                         description: "Resolves using the unique Content id."
-                        type: "Int"
+                        type: "ID!"
                     remoteId:
                         description: "Resolves using the unique Content remote id."
                         type: "String"
@@ -68,10 +68,10 @@ Repository:
                     groupIdentifier:
                         type: "String"
                 resolve: "@=resolver('ContentTypesFromGroup', [args])"
-
             searchContent:
                 type: "[Content]"
                 args:
                     query:
                         type: "ContentSearchQuery!"
                 resolve: "@=resolver('SearchContent', [args])"
+

--- a/Resources/config/graphql/Search.types.yml
+++ b/Resources/config/graphql/Search.types.yml
@@ -23,6 +23,22 @@ ContentSearchQuery:
             Field:
                 type: "FieldCriterionInput"
                 description: "Field filter"
+            SortBy:
+                type: "SortByOptions"
+
+SortByOptions:
+    type: enum
+    config:
+        values:
+            ContentId: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId'
+            ContentName: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentName'
+            DateModified: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\DateModified'
+            DatePublished: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished'
+            # field: not implemented yet
+            Location: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location'
+            # MapLocationDistance: not implemented yet
+            SectionIdentifier: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionIdentifier'
+            SectionName: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionName'
 
 FieldCriterionInput:
      type: "input-object"

--- a/Resources/config/graphql/relay/Node.types.yml
+++ b/Resources/config/graphql/relay/Node.types.yml
@@ -1,0 +1,7 @@
+# interface Node {
+#   id: ID!
+# }
+Node:
+    type: relay-node
+    config:
+        resolveType: '@=resolver("node_type", [value])'

--- a/Resources/config/resolvers.yml
+++ b/Resources/config/resolvers.yml
@@ -110,6 +110,7 @@ services:
             $contentService: "@ezpublish.siteaccessaware.service.content"
             $variations: "$image_variations$"
         tags:
+            - { name: overblog_graphql.resolver, alias: "ImageVariations", method: "resolveImageVariations" }
             - { name: overblog_graphql.resolver, alias: "ImageVariation", method: "resolveImageVariation" }
 
     BD\EzPlatformGraphQLBundle\GraphQL\Resolver\DateResolver:

--- a/Resources/config/resolvers.yml
+++ b/Resources/config/resolvers.yml
@@ -49,6 +49,7 @@ services:
             $contentService: '@ezpublish.siteaccessaware.service.content'
             $contentTypeService: '@ezpublish.siteaccessaware.service.content_type'
             $locationService: '@ezpublish.siteaccessaware.service.location'
+            $contentTypeHandler: '@ezpublish.spi.persistence.content_type_handler'
 
     BD\EzPlatformGraphQLBundle\GraphQL\Resolver\UserResolver:
         tags:
@@ -124,3 +125,12 @@ services:
     BD\EzPlatformGraphQLBundle\GraphQL\Resolver\SelectionFieldResolver:
         tags:
             - { name: overblog_graphql.resolver, alias: "SelectionFieldValue", method: "resolveSelectionFieldValue"}
+
+    BD\EzPlatformGraphQLBundle\GraphQL\Relay\NodeResolver:
+        tags:
+            - { name: overblog_graphql.resolver, alias: "node", method: "resolveNode" }
+            - { name: overblog_graphql.resolver, alias: "node_type", method: "resolveType" }
+
+    BD\EzPlatformGraphQLBundle\GraphQL\Relay\SearchResolver:
+        tags:
+            - {name: overblog_graphql.resolver, alias: "SearchContentConnection", method: "searchContent"}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,20 +1,25 @@
 services:
-    BD\EzPlatformGraphQLBundle\Command\GeneratePlatformDomainTypesCommand:
+    _defaults:
         autoconfigure: true
         autowire: true
+        public: false
+
+    BD\EzPlatformGraphQLBundle\Command\GeneratePlatformSchemaCommand:
         tags:
             -  { name: console.command }
 
-    BD\EzPlatformGraphQLBundle\Command\GeneratePlatformSchemaCommand:
-        autoconfigure: true
-        autowire: true
+    BD\EzPlatformGraphQLBundle\Command\GeneratePlatformDomainTypesCommand:
         tags:
             -  { name: console.command }
+
+    BD\EzPlatformGraphQLBundle\GraphQL\Resolver\LocationResolver:
+        arguments:
+            - "@ezpublish.api.repository"
 
     BD\EzPlatformGraphQLBundle\GraphQL\TypeDefinition\ContentTypeMapper: ~
 
-    bd_ezplatform_graphql.graph.mutation.section:
-        class: BD\EzPlatformGraphQLBundle\GraphQL\Mutation\SectionMutation
+
+    BD\EzPlatformGraphQLBundle\GraphQL\Mutation\SectionMutation:
         arguments:
             - "@ezpublish.api.service.section"
         tags:

--- a/Schema/ImagesVariationsBuilder.php
+++ b/Schema/ImagesVariationsBuilder.php
@@ -1,0 +1,36 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\Schema;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+
+/**
+ * Generates the ImageVariationIdentifier enum that indexes images variations identifiers.
+ */
+class ImagesVariationsBuilder implements SchemaBuilder
+{
+    /**
+     * @var ConfigResolver
+     */
+    private $configResolver;
+
+    public function __construct(ConfigResolver $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    public function build(array &$schema)
+    {
+        $schema['ImageVariationIdentifier'] = [
+            'type' => 'enum',
+            'config' => [
+                'values' => []
+            ]
+        ];
+
+        $values =& $schema['ImageVariationIdentifier']['config']['values'];
+
+        foreach (array_keys($this->configResolver->getParameter('image_variations')) as $variationIdentifier) {
+            $values[$variationIdentifier] = [];
+        }
+    }
+}

--- a/TODO.md
+++ b/TODO.md
@@ -12,3 +12,5 @@
   Dedicated ContentType objects would be instances of their ContentType, and provide
   direct access to their fields.
   `ArticleContent` would have `title`, `intro`, `body` and `image` fields.
+- Fix lists by adding the `edges {cursor node}` structure specified by Relay
+  https://facebook.github.io/relay/graphql/connections.htm

--- a/doc/domain_schema.md
+++ b/doc/domain_schema.md
@@ -34,9 +34,9 @@ Queries look like this:
 
 Run `php bin/console bd:platform-graphql:generate-domain-schema` from the root of your
 eZ Platform installation. It will go over your repository, and generate the matching
-types in `src/AppBundle/Resources/graphql/`.
+types in `app/config/graphql/`.
 
-Open `<host>/graphiql/domain`. The content type groups, content types and their fields
+Open `<host>/graphiql`. The content type groups, content types and their fields
 will be exposed as the schema.
 
 ## Customizing the schema


### PR DESCRIPTION
> Issues: #21

Changes lists of content items to [Connections](https://facebook.github.io/relay/graphql/connections.htm):

```
{
  content {
    blogPosts(sortBy: DatePublished, last: 5) {
      pageInfo {
        hasNextPage
      }
      edges {
        cursor
        node {
          title
        }
      }
    }
  }
}
```

Allows to implement [pagination](https://facebook.github.io/relay/docs/en/pagination-container.html), as well as individual items refetching.

### TODO
- [ ] Fix ID handling: domain content items will return a Global Id, that can not be used for fetching individual items. This needs to be unified
- [ ] Verify the impact of globally changing resolution of searches by type identifier to a connection. It has probably broken some stuff.