### PR TITLE
Added proper DateTime handling

### DIFF
--- a/GraphQL/Resolver/DateResolver.php
+++ b/GraphQL/Resolver/DateResolver.php
@@ -1,0 +1,21 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\GraphQL\Resolver;
+
+use DateTime;
+use Overblog\GraphQLBundle\Definition\Argument;
+
+class DateResolver
+{
+    public function resolveDateToFormat(DateTime $date, Argument $args)
+    {
+        if (isset($args['constant'])) {
+            $format = $args['constant'];
+        } else if (isset($args['format'])) {
+            $format = $args['format'];
+        } else {
+            $format = DateTime::RFC850;
+        }
+
+        return $date->format($format);
+    }
+}

--- a/Resources/config/graphql/Base.types.yml
+++ b/Resources/config/graphql/Base.types.yml
@@ -1,0 +1,36 @@
+DateFormatConstant:
+    type: enum
+    config:
+        values:
+            atom: {value: "@=constant('DateTime::ATOM')", description: "Y-m-d\\TH:i:sP"}
+            cookie: {value: "@=constant('DateTime::COOKIE')", description: "l, d-M-Y H:i:s T"}
+            iso8601: {value: "@=constant('DateTime::ISO8601')", description: "Y-M-D\\TH:I:SO"}
+            rfc822: {value: "@=constant('DateTime::RFC822')", description: "D, D M Y H:I:S O"}
+            rfc850: {value: "@=constant('DateTime::RFC850')", description: "L, D-M-Y H:I:S T"}
+            rfc1036: {value: "@=constant('DateTime::RFC1036')", description: "D, D M Y H:I:S O"}
+            rfc1123: {value: "@=constant('DateTime::RFC1123')", description: "D, D M Y H:I:S O"}
+            rfc2822: {value: "@=constant('DateTime::RFC2822')", description: "D, D M Y H:I:S O"}
+            rfc3339: {value: "@=constant('DateTime::RFC3339')", description: "Y-M-D\\TH:I:SP"}
+            rfc3339_extended: {value: "@=constant('DateTime::RFC3339_EXTENDED')", description: "Y-M-D\\TH:I:S.VP"}
+            rss: {value: "@=constant('DateTime::RSS')", description: "D, D M Y H:I:S O"}
+            w3c: {value: "@=constant('DateTime::W3C')", description: "Y-M-D\\TH:I:SP"}
+
+DateTime:
+    type: object
+    config:
+        description: "A date"
+        fields:
+            format:
+                type: String
+                description: "Date formatted with a date() format"
+                resolve: "@=resolver('DateTimeFormat', [value, args])"
+                args:
+                    format:
+                        type: "String"
+                        description: "A format compatible with date()"
+                    constant:
+                        type: DateFormatConstant
+            timestamp:
+                description: "The raw string value"
+                type: Int
+                resolve: "@=value.getTimestamp()"

--- a/Resources/config/graphql/Content.types.yml
+++ b/Resources/config/graphql/Content.types.yml
@@ -60,10 +60,10 @@ Content:
                 description: "The owner user of the Content object"
                 resolve: "@=resolver('UserById', [value.ownerId])"
             modificationDate:
-                type: "String"
+                type: DateTime
                 description: "Date the Content item was last modified on."
             publishedDate:
-                type: "String"
+                type: DateTime
                 description: "Date the Content item was first published on."
             alwaysAvailable:
                 type: "Boolean"
@@ -136,7 +136,7 @@ ContentCreateStruct:
                 type: "String"
                 description: "The main language code for the content."
             modificationDate:
-                type: "String"
+                type: "DateTime"
                 description: "Modification date. If not given the current timestamp is used."
             fields:
                 type: "[Field]"

--- a/Resources/config/graphql/ContentType.types.yml
+++ b/Resources/config/graphql/ContentType.types.yml
@@ -31,10 +31,10 @@ ContentType:
                 type: "[String]"
                 description: "The Content Type's names in all languages"
             creationDate:
-                type: "String"
+                type: "DateTime"
                 description: "The date of the creation of this Content Type."
             modificationDate:
-                type: "String"
+                type: "DateTime"
                 description: "the date of the last modification of this Content Type."
             creatorId:
                 type: "Int"
@@ -89,9 +89,9 @@ ContentTypeGroup:
             identifier:
                 type: "String"
             creationDate:
-                type: "String"
+                type: "DateTime"
             modificationDate:
-                type: "String"
+                type: "DateTime"
             creatorId:
                 type: "Int"
             creator:

--- a/Resources/config/graphql/Field.types.yml
+++ b/Resources/config/graphql/Field.types.yml
@@ -159,7 +159,7 @@ DateFieldValue:
     config:
         interfaces: [FieldValue]
         fields:
-            text:
+            format:
                 type: "String"
                 description: "String representation of the value"
                 resolve: "@=value"

--- a/Resources/config/graphql/Version.types.yml
+++ b/Resources/config/graphql/Version.types.yml
@@ -19,9 +19,9 @@ Version:
                     languageCode:
                         type: "String"
             modificationDate:
-                type: "String"
+                type: "DateTime"
             creationDate:
-                type: "String"
+                type: "DateTime"
             creatorId:
                 type: "Int"
             #creator:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -103,3 +103,7 @@ services:
         tags:
             - { name: "overblog_graphql.mutation", alias: "CreateSection", method: "createSection" }
             - { name: "overblog_graphql.mutation", alias: "DeleteSection", method: "deleteSection" }
+
+    BD\EzPlatformGraphQLBundle\GraphQL\Resolver\DateResolver:
+        tags:
+            - { name: overblog_graphql.resolver, alias: "DateTimeFormat", method: "resolveDateToFormat"}


### PR DESCRIPTION
All DateTime properties now have their own type, with custom fields:
- `format`, that formats the date, either with:
  - a datetime constant `format(constant: atom)`
  - a format string: `format(string: "d/m/Y")`
- `timestamp`, that returns the DateTime's timestamp.

### Examples
![image](https://user-images.githubusercontent.com/235928/41464197-b2ec7790-7099-11e8-9435-53bb080e9bbe.png)

```json
{
  "data": {
    "searchContent": [
      {
        "name": "Where we get our best writing done",
        "modificationDate": {
          "format": "Monday, 04-Jun-18 12:08:04 UTC"
        }
      }
    ]
  }
}
```