### PR TITLE
[prototype] natural content filtering

### DIFF
--- a/DependencyInjection/Factory/SearchFeaturesFactory.php
+++ b/DependencyInjection/Factory/SearchFeaturesFactory.php
@@ -1,0 +1,35 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\DependencyInjection\Factory;
+
+use BD\EzPlatformGraphQLBundle\Search\SearchFeatures;
+use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
+
+class SearchFeaturesFactory
+{
+    /**
+     * @var RepositoryConfigurationProvider
+     */
+    private $configurationProvider;
+
+    /**
+     * @var SearchFeatures[]
+     */
+    private $searchFeatures = [];
+
+    public function __construct(RepositoryConfigurationProvider $configurationProvider, array $searchFeatures)
+    {
+        $this->configurationProvider = $configurationProvider;
+        $this->searchFeatures = $searchFeatures;
+    }
+
+    public function build()
+    {
+        $searchEngine = $this->configurationProvider->getRepositoryConfig()['search']['engine'];
+
+        if (isset($this->searchFeatures[$searchEngine])) {
+            return $this->searchFeatures[$searchEngine];
+        } else {
+            throw new \InvalidArgumentException("Search engine not found");
+        }
+    }
+}

--- a/DomainContent/SchemaWorker/ContentType/AddDomainContentToDomainGroup.php
+++ b/DomainContent/SchemaWorker/ContentType/AddDomainContentToDomainGroup.php
@@ -83,7 +83,7 @@ class AddDomainContentToDomainGroup extends BaseWorker implements SchemaWorker
             && $args['ContentType'] instanceof ContentType
             && isset($args['ContentTypeGroup'])
             && $args['ContentTypeGroup'] instanceof ContentTypeGroup
-            && !$this->isFieldDefined($args['ContentTypeGroup'], $args['ContentType']);
+            && !$this->isFieldDefined($schema, $args['ContentTypeGroup'], $args['ContentType']);
     }
 
     /**
@@ -131,7 +131,7 @@ class AddDomainContentToDomainGroup extends BaseWorker implements SchemaWorker
         return $this->getNameHelper()->domainContentName($contentType);
     }
 
-    private function isFieldDefined(ContentTypeGroup $contentTypeGroup, ContentType $contentType)
+    private function isFieldDefined($schema, ContentTypeGroup $contentTypeGroup, ContentType $contentType)
     {
         return isset(
             $schema

--- a/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToCollectionFilters.php
+++ b/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToCollectionFilters.php
@@ -1,0 +1,91 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\FieldDefinition;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\FieldValueBuilder\FieldValueBuilder;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\BaseWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\SchemaWorker;
+use BD\EzPlatformGraphQLBundle\Search\SearchFeatures;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
+use eZ\Publish\Core\Repository\Helper\FieldTypeRegistry;
+
+/**
+ * Adds the field definition, if it is searchable, as a filter on the type's collection.
+ */
+class AddFieldDefinitionToCollectionFilters extends BaseWorker implements SchemaWorker
+{
+    /**
+     * @var SearchFeatures
+     */
+    private $searchFeatures;
+
+    public function __construct(SearchFeatures $searchFeatures)
+    {
+        $this->searchFeatures = $searchFeatures;
+    }
+
+    public function work(array &$schema, array $args)
+    {
+        $domainGroupName = $this->getNameHelper()->domainGroupName($args['ContentTypeGroup']);
+        $domainContentCollectionField = $this->getNameHelper()->domainContentCollectionField($args['ContentType']);
+        $fieldDefinitionField = $this->getNameHelper()->fieldDefinitionField($args['FieldDefinition']);
+
+        $filter = [
+            'type' => $this->getFilterType($args['FieldDefinition']),
+            'description' => 'Filter content based on the ' . $args['FieldDefinition']->identifier . ' field',
+        ];
+
+        $schema
+            [$domainGroupName]
+            ['config']['fields']
+            [$domainContentCollectionField]
+            ['args'][$fieldDefinitionField] = $filter;
+    }
+
+    public function canWork(array &$schema, array $args)
+    {
+        return
+            isset($args['FieldDefinition'])
+            && $args['FieldDefinition'] instanceof FieldDefinition
+            & isset($args['ContentType'])
+            && $args['ContentType'] instanceof ContentType
+            && $this->searchFeatures->supportsFieldCriterion($args['FieldDefinition']);
+    }
+
+    /**
+     * @param ContentType $contentType
+     * @return string
+     */
+    protected function getDomainContentName(ContentType $contentType): string
+    {
+        return $this->getNameHelper()->domainContentName($contentType);
+    }
+
+    /**
+     * @param FieldDefinition $fieldDefinition
+     * @return string
+     */
+    protected function getFieldDefinitionField(FieldDefinition $fieldDefinition): string
+    {
+        return $this->getNameHelper()->fieldDefinitionField($fieldDefinition);
+    }
+
+    private function isSearchable(FieldDefinition $fieldDefinition): bool
+    {
+        return $fieldDefinition->isSearchable
+            // should only be verified if legacy is the current search engine
+            && $this->converterRegistry->getConverter($fieldDefinition->fieldTypeIdentifier)->getIndexColumn() !== false;
+    }
+
+    private function getFilterType(FieldDefinition $fieldDefinition)
+    {
+        switch ($fieldDefinition->fieldTypeIdentifier)
+        {
+            case 'ezboolean':
+                return 'Boolean';
+            default:
+                return 'String';
+        }
+    }
+}

--- a/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToCollectionFilters.php
+++ b/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToCollectionFilters.php
@@ -43,7 +43,7 @@ class AddFieldDefinitionToCollectionFilters extends BaseWorker implements Schema
             ['args'][$fieldDefinitionField] = $filter;
     }
 
-    public function canWork(array &$schema, array $args)
+    public function canWork(array $schema, array $args)
     {
         return
             isset($args['FieldDefinition'])

--- a/GraphQL/Resolver/DomainContentResolver.php
+++ b/GraphQL/Resolver/DomainContentResolver.php
@@ -223,13 +223,11 @@ class DomainContentResolver
         if (is_array($value) && count($value) === 1) {
             $value = $value[0];
         }
-        $operator = $operator = Query\Criterion\Operator::EQ;
-        ;
+        $operator = 'eq';
 
+        // @todo if 3 items, and first item is 'between', use next two items as value
         if (is_array($value)) {
             $operator = 'in';
-
-            // @todo if 3 items, and first item is 'between', use next two items as value
         } else if (is_string($value)) {
             if ($value[0] === '~') {
                 $operator = 'like';

--- a/GraphQL/Resolver/DomainContentResolver.php
+++ b/GraphQL/Resolver/DomainContentResolver.php
@@ -223,30 +223,32 @@ class DomainContentResolver
         if (is_array($value) && count($value) === 1) {
             $value = $value[0];
         }
-        $operator = 'eq';
+        $operator = $operator = Query\Criterion\Operator::EQ;
+        ;
 
         if (is_array($value)) {
             $operator = 'in';
+
             // @todo if 3 items, and first item is 'between', use next two items as value
         } else if (is_string($value)) {
             if ($value[0] === '~') {
-                $value = substr($value, 1);
                 $operator = 'like';
+                $value = substr($value, 1);
                 if (strpos($value, '%') === false) {
                     $value = "%$value%";
                 }
             } elseif ($value[0] === '<') {
                 $value = substr($value, 1);
-                if ($value{1} === '=') {
+                if ($value[0] === '=') {
                     $operator = 'lte';
                     $value = substr($value, 2);
                 } else {
-                    $value = substr($value, 1);
                     $operator = 'lt';
+                    $value = substr($value, 1);
                 }
             } elseif ($value[0] === '<') {
                 $value = substr($value, 1);
-                if ($value[1] === '=') {
+                if ($value[0] === '=') {
                     $operator = 'gte';
                     $value = substr($value, 2);
                 } else {

--- a/GraphQL/Resolver/DomainContentResolver.php
+++ b/GraphQL/Resolver/DomainContentResolver.php
@@ -220,20 +220,22 @@ class DomainContentResolver
 
     private function buildFieldFilter($fieldDefinitionIdentifier, $value)
     {
-        if (count($value) === 1) {
+        if (is_array($value) && count($value) === 1) {
             $value = $value[0];
         }
+        $operator = 'eq';
+
         if (is_array($value)) {
             $operator = 'in';
             // @todo if 3 items, and first item is 'between', use next two items as value
         } else if (is_string($value)) {
-            if ($value{0} === '~') {
+            if ($value[0] === '~') {
                 $value = substr($value, 1);
                 $operator = 'like';
                 if (strpos($value, '%') === false) {
                     $value = "%$value%";
                 }
-            } elseif ($value{0} === '<') {
+            } elseif ($value[0] === '<') {
                 $value = substr($value, 1);
                 if ($value{1} === '=') {
                     $operator = 'lte';
@@ -242,17 +244,15 @@ class DomainContentResolver
                     $value = substr($value, 1);
                     $operator = 'lt';
                 }
-            } elseif ($value{0} === '<') {
+            } elseif ($value[0] === '<') {
                 $value = substr($value, 1);
-                if ($value{1} === '=') {
+                if ($value[1] === '=') {
                     $operator = 'gte';
                     $value = substr($value, 2);
                 } else {
                     $operator = 'gt';
                     $value = substr($value, 1);
                 }
-            } else {
-                $operator = 'eq';
             }
         }
 

--- a/Resources/config/domain_content.yml
+++ b/Resources/config/domain_content.yml
@@ -33,6 +33,10 @@ services:
 
     BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentTypeGroup\AddDomainGroupToDomain: ~
 
+    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\FieldDefinition\AddFieldDefinitionToCollectionFilters:
+        arguments:
+            $searchFeatures: '@BD\EzPlatformGraphQLBundle\Search\SearchFeatures'
+
     BD\EzPlatformGraphQLBundle\DomainContent\FieldValueBuilder\BaseFieldValueBuilder: ~
 
     BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\FieldDefinition\AddFieldDefinitionToDomainContent:

--- a/Resources/config/graphql/FieldDefinition.types.yml
+++ b/Resources/config/graphql/FieldDefinition.types.yml
@@ -39,7 +39,9 @@ FieldDefinition:
             isRequired:
                 type: Boolean
                 description: "Indicates if this field is used for information collection"
-
+            isSearchable:
+                type: Boolean
+                description: "Indicates if the content is searchable by this attribute"
 CheckboxFieldDefinition:
     type: object
     inherits: [FieldDefinition]

--- a/Resources/config/resolvers.yml
+++ b/Resources/config/resolvers.yml
@@ -45,10 +45,7 @@ services:
             - { name: overblog_graphql.resolver, alias: "DomainContentItem", method: "resolveDomainContentItem" }
             - { name: overblog_graphql.resolver, alias: "DomainRelationFieldValue", method: "resolveDomainRelationFieldValue" }
         arguments:
-            $searchService: '@ezpublish.siteaccessaware.service.search'
-            $contentService: '@ezpublish.siteaccessaware.service.content'
-            $contentTypeService: '@ezpublish.siteaccessaware.service.content_type'
-            $locationService: '@ezpublish.siteaccessaware.service.location'
+            $repository: "@ezpublish.siteaccessaware.repository"
 
     BD\EzPlatformGraphQLBundle\GraphQL\Resolver\UserResolver:
         tags:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,3 +22,19 @@ services:
             - { name: "overblog_graphql.mutation", alias: "DeleteSection", method: "deleteSection" }
 
     BD\EzPlatformGraphQLBundle\GraphQL\InputMapper\SearchQueryMapper: ~
+
+    BD\EzPlatformGraphQLBundle\DependencyInjection\Factory\SearchFeaturesFactory:
+        arguments:
+            $configurationProvider: '@ezpublish.api.repository_configuration_provider'
+            $searchFeatures:
+                solr: '@BD\EzPlatformGraphQLBundle\Search\SolrSearchFeatures'
+                legacy: '@BD\EzPlatformGraphQLBundle\Search\LegacySearchFeatures'
+
+    BD\EzPlatformGraphQLBundle\Search\SearchFeatures:
+        factory: ['@BD\EzPlatformGraphQLBundle\DependencyInjection\Factory\SearchFeaturesFactory', build]
+
+    BD\EzPlatformGraphQLBundle\Search\LegacySearchFeatures:
+        arguments:
+            $converterRegistry: '@ezpublish.persistence.legacy.field_value_converter.registry'
+
+    BD\EzPlatformGraphQLBundle\Search\SolrSearchFeatures: ~

--- a/Search/LegacySearchFeatures.php
+++ b/Search/LegacySearchFeatures.php
@@ -1,0 +1,23 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\Search;
+
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
+
+class LegacySearchFeatures implements SearchFeatures
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry
+     */
+    private $converterRegistry;
+
+    public function __construct(ConverterRegistry $converterRegistry)
+    {
+        $this->converterRegistry = $converterRegistry;
+    }
+
+    public function supportsFieldCriterion(FieldDefinition $fieldDefinition)
+    {
+        return $this->converterRegistry->getConverter($fieldDefinition->fieldTypeIdentifier)->getIndexColumn() !== false;
+    }
+}

--- a/Search/SearchFeatures.php
+++ b/Search/SearchFeatures.php
@@ -1,0 +1,16 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\Search;
+
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+
+interface SearchFeatures
+{
+    /**
+     * Tests if search supports field filtering on $fieldDefinition.
+     *
+     * @param FieldDefinition $fieldDefinition
+     *
+     * @return bool
+     */
+    public function supportsFieldCriterion(FieldDefinition $fieldDefinition);
+}

--- a/Search/SolrSearchFeatures.php
+++ b/Search/SolrSearchFeatures.php
@@ -1,0 +1,12 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\Search;
+
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+
+class SolrSearchFeatures implements SearchFeatures
+{
+    public function supportsFieldCriterion(FieldDefinition $fieldDefinition)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
The collection field for a type (`articles`, `blogPosts`) will expose an argument
for each searchable field:

```
{
  media {
    images(name: "~norway") {
      _name
    }
  }
  content {
    products(price: "> 20", gluten: false) {
      _name
    }
  }
}
```

Supported operators (as first characters of the string): ~ (like, with automatic wildcards), <, >, <=, >=).

### TODO
- [ ] Add syntax for `not` (`!~norway`)
- [ ] Accept array of values arguments where at least one value has an operator as a OR.
- [ ] Handle date fields (`publicationDate: "< 2018/11/10"`)
- [ ] Refactor fields filters processing, and ideally unit test it.
- [x] Figure out what's "searchable" when the LSE is used. It is actually detected when converting the criteria using the LegacyConverter's `getIndexColumn()` method, that returns `false` for these fields. It may have to be taken into account at schema generation's time, but the schema will then depend on the environment / search engine.
- [ ] Reintroduce non-field filters (fulltext, parent location...), probably prefixed with `_`
- [ ] Add fields to `sortBy` as well
