### PR TITLE
Content mutations

### DIFF
--- a/DependencyInjection/BDEzPlatformGraphQLExtension.php
+++ b/DependencyInjection/BDEzPlatformGraphQLExtension.php
@@ -44,7 +44,13 @@ class BDEzPlatformGraphQLExtension extends Extension implements PrependExtension
 
     private function getGraphQLConfig()
     {
-        $schema['platform'] = ['query' => 'Platform', 'mutation' => 'PlatformMutation'];
+        $schema = [
+            'platform' => [
+                'query' => 'Platform',
+                'mutation' => 'PlatformMutation',
+                'resolver_maps' => ['BD\EzPlatformGraphQLBundle\GraphQL\Resolver\Map\UploadMap'],
+            ]
+        ];
 
         if (file_exists(self::DOMAIN_SCHEMA_FILE)) {
             $schema['platform']['query'] = 'Domain';

--- a/DependencyInjection/BDEzPlatformGraphQLExtension.php
+++ b/DependencyInjection/BDEzPlatformGraphQLExtension.php
@@ -44,15 +44,14 @@ class BDEzPlatformGraphQLExtension extends Extension implements PrependExtension
 
     private function getGraphQLConfig()
     {
-        $schemaFilePath = self::DOMAIN_SCHEMA_FILE;
+        $schema['platform'] = ['query' => 'Platform', 'mutation' => 'PlatformMutation'];
 
-        if (!file_exists($schemaFilePath)) {
-            $schema['platform'] = ['query' => 'Platform'];
-        } else {
-            $schema['platform'] = ['query' => 'Domain'];
-            if (file_exists(self::DOMAIN_MUTATION_FILE)) {
-                $schema['platform']['mutation'] = 'DomainContentMutation';
-            }
+        if (file_exists(self::DOMAIN_SCHEMA_FILE)) {
+            $schema['platform']['query'] = 'Domain';
+        }
+
+        if (file_exists(self::DOMAIN_MUTATION_FILE)) {
+            $schema['platform']['mutation'] = 'DomainContentMutation';
         }
 
         // Deprecated, use the default schema with the '_repository field instead.

--- a/DependencyInjection/BDEzPlatformGraphQLExtension.php
+++ b/DependencyInjection/BDEzPlatformGraphQLExtension.php
@@ -17,6 +17,7 @@ use Symfony\Component\Yaml\Yaml;
 class BDEzPlatformGraphQLExtension extends Extension implements PrependExtensionInterface
 {
     const DOMAIN_SCHEMA_FILE = __DIR__. '/../../../../app/config/graphql/Domain.types.yml';
+    const DOMAIN_MUTATION_FILE = __DIR__. '/../../../../app/config/graphql/DomainMutation.types.yml';
 
     /**
      * {@inheritdoc}
@@ -49,6 +50,9 @@ class BDEzPlatformGraphQLExtension extends Extension implements PrependExtension
             $schema['platform'] = ['query' => 'Platform'];
         } else {
             $schema['platform'] = ['query' => 'Domain'];
+            if (file_exists(self::DOMAIN_MUTATION_FILE)) {
+                $schema['platform']['mutation'] = 'DomainContentMutation';
+            }
         }
 
         // Deprecated, use the default schema with the '_repository field instead.

--- a/DomainContent/NameHelper.php
+++ b/DomainContent/NameHelper.php
@@ -36,9 +36,14 @@ class NameHelper
         return ucfirst($this->toCamelCase($contentType->identifier)) . 'Content';
     }
 
-    public function domainContentInputName(ContentType $contentType)
+    public function domainContentCreateInputName(ContentType $contentType)
     {
-        return ucfirst($this->toCamelCase($contentType->identifier)) . 'ContentInput';
+        return ucfirst($this->toCamelCase($contentType->identifier)) . 'ContentCreateInput';
+    }
+
+    public function domainContentUpdateInputName($contentType)
+    {
+        return ucfirst($this->toCamelCase($contentType->identifier)) . 'ContentUpdateInput';
     }
 
     public function domainContentTypeName(ContentType $contentType)
@@ -51,11 +56,15 @@ class NameHelper
         return lcfirst($this->toCamelCase($contentType->identifier));
     }
 
-    public function domainMutationCreateField($contentType)
+    public function domainMutationCreateContentField($contentType)
     {
         return 'create' . ucfirst($this->domainContentField($contentType));
     }
 
+    public function domainMutationUpdateContentField($contentType)
+    {
+        return 'update' . ucfirst($this->domainContentField($contentType));
+    }
 
     public function domainGroupName(ContentTypeGroup $contentTypeGroup)
     {

--- a/DomainContent/NameHelper.php
+++ b/DomainContent/NameHelper.php
@@ -30,9 +30,15 @@ class NameHelper
     {
         return $this->pluralize(lcfirst($this->toCamelCase($contentType->identifier)));
     }
+
     public function domainContentName(ContentType $contentType)
     {
         return ucfirst($this->toCamelCase($contentType->identifier)) . 'Content';
+    }
+
+    public function domainContentInputName(ContentType $contentType)
+    {
+        return ucfirst($this->toCamelCase($contentType->identifier)) . 'ContentInput';
     }
 
     public function domainContentTypeName(ContentType $contentType)
@@ -44,6 +50,12 @@ class NameHelper
     {
         return lcfirst($this->toCamelCase($contentType->identifier));
     }
+
+    public function domainMutationCreateField($contentType)
+    {
+        return 'create' . ucfirst($this->domainContentField($contentType));
+    }
+
 
     public function domainGroupName(ContentTypeGroup $contentTypeGroup)
     {

--- a/DomainContent/SchemaWorker/ContentType/DefineDomainContentMutation.php
+++ b/DomainContent/SchemaWorker/ContentType/DefineDomainContentMutation.php
@@ -23,6 +23,7 @@ class DefineDomainContentMutation extends BaseWorker implements SchemaWorker
         if (!isset($schema['DomainContentMutation'])) {
             $schema['DomainContentMutation'] = [
                 'type' => 'object',
+                'inherits' => ['PlatformMutation'],
                 'config' => [
                     'fields' => []
                 ]

--- a/DomainContent/SchemaWorker/ContentType/DefineDomainContentMutation.php
+++ b/DomainContent/SchemaWorker/ContentType/DefineDomainContentMutation.php
@@ -11,15 +11,8 @@ class DefineDomainContentMutation extends BaseWorker implements SchemaWorker
     public function work(array &$schema, array $args)
     {
         $contentType = $args['ContentType'];
-        $domainContentInputName = $this->getNameHelper()->domainContentInputName($contentType);
 
-        $schema[$domainContentInputName] = [
-            'type' => 'input-object',
-            'config' => [
-                'fields' => [],
-            ]
-        ];
-
+        // This should ideally be some "init" worker type
         if (!isset($schema['DomainContentMutation'])) {
             $schema['DomainContentMutation'] = [
                 'type' => 'object',
@@ -30,24 +23,51 @@ class DefineDomainContentMutation extends BaseWorker implements SchemaWorker
             ];
         }
 
+        // create mutation field
         $schema
             ['DomainContentMutation']
             ['config']['fields']
-            [$this->getNameHelper()->domainMutationCreateField($contentType)] = [
+            [$this->getCreateField($contentType)] = [
+                // @todo Use payload
                 'type' => $this->getNameHelper()->domainContentName($contentType) . '!',
                 'resolve' => sprintf(
                     '@=mutation("CreateDomainContent", [args["input"], "%s", args["parentLocationId"], args["language"]])',
                     $contentType->identifier
                 ),
                 'args' => [
-                    'input' => ['type' => $domainContentInputName],
+                    'input' => ['type' => $this->getCreateInputName($contentType) . '!'],
                     'language' => ['type' => 'String', 'defaultValue' => "eng-GB"],
                     'parentLocationId' => ['type' => 'Int!'],
                 ],
             ];
 
-        // Domain content input type, no fields
-        $schema[$domainContentInputName] = [
+        // Create mutation input type, no fields
+        $schema[$this->getCreateInputName($contentType)] = [
+            'type' => 'input-object',
+            'config' => [
+                'fields' => []
+            ]
+        ];
+
+        // Update mutation field
+        $schema
+            ['DomainContentMutation']
+            ['config']['fields']
+            [$this->getUpdateField($contentType)] = [
+            // @todo Use payload
+            'type' => $this->getNameHelper()->domainContentName($contentType) . '!',
+            'resolve' => '@=mutation("UpdateDomainContent", [args["input"], args, args["versionNo"], args["language"]])',
+            'args' => [
+                'input' => ['type' => $this->getUpdateInputName($contentType) . '!'],
+                'language' => ['type' => 'String', 'defaultValue' => "eng-GB"],
+                'id' =>  ['type' => 'ID', 'description' => 'ID of the content item to update'],
+                'contentId' => ['type' => 'Int', 'description' => 'ID of the content item to update'],
+                'versionNo' => ['type' => 'Int', 'description' => 'Optional version number to update. If it is a draft, it is saved, not published. If it is archived, it is used as the source version for the update, to complete missing fields.'],
+            ],
+        ];
+
+        // Update mutation input
+        $schema[$this->getUpdateInputName($contentType)] = [
             'type' => 'input-object',
             'config' => [
                 'fields' => []
@@ -57,8 +77,44 @@ class DefineDomainContentMutation extends BaseWorker implements SchemaWorker
 
     public function canWork(array $schema, array $args)
     {
-        return
-            isset($args['ContentType']) && $args['ContentType'] instanceof ContentType
-            && !isset($schema[$this->getNameHelper()->domainContentInputName($args['ContentType'])]);
+        return isset($args['ContentType'])
+               && $args['ContentType'] instanceof ContentType
+               && !isset($args['FieldDefinition']);
+    }
+
+    /**
+     * @param $contentType
+     * @return string
+     */
+    protected function getCreateInputName($contentType): string
+    {
+        return $this->getNameHelper()->domainContentCreateInputName($contentType);
+    }
+
+    /**
+     * @param $contentType
+     * @return string
+     */
+    protected function getUpdateInputName($contentType): string
+    {
+        return $this->getNameHelper()->domainContentUpdateInputName($contentType);
+    }
+
+    /**
+     * @param $contentType
+     * @return string
+     */
+    protected function getCreateField($contentType): string
+    {
+        return $this->getNameHelper()->domainMutationCreateContentField($contentType);
+    }
+
+    /**
+     * @param $contentType
+     * @return string
+     */
+    protected function getUpdateField($contentType): string
+    {
+        return $this->getNameHelper()->domainMutationUpdateContentField($contentType);
     }
 }

--- a/DomainContent/SchemaWorker/ContentType/DefineDomainContentMutation.php
+++ b/DomainContent/SchemaWorker/ContentType/DefineDomainContentMutation.php
@@ -1,0 +1,63 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\BaseWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\SchemaWorker;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
+
+class DefineDomainContentMutation extends BaseWorker implements SchemaWorker
+{
+    public function work(array &$schema, array $args)
+    {
+        $contentType = $args['ContentType'];
+        $domainContentInputName = $this->getNameHelper()->domainContentInputName($contentType);
+
+        $schema[$domainContentInputName] = [
+            'type' => 'input-object',
+            'config' => [
+                'fields' => [],
+            ]
+        ];
+
+        if (!isset($schema['DomainContentMutation'])) {
+            $schema['DomainContentMutation'] = [
+                'type' => 'object',
+                'config' => [
+                    'fields' => []
+                ]
+            ];
+        }
+
+        $schema
+            ['DomainContentMutation']
+            ['config']['fields']
+            [$this->getNameHelper()->domainMutationCreateField($contentType)] = [
+                'type' => $this->getNameHelper()->domainContentName($contentType) . '!',
+                'resolve' => sprintf(
+                    '@=mutation("CreateDomainContent", [args["input"], "%s", args["parentLocationId"], args["language"]])',
+                    $contentType->identifier
+                ),
+                'args' => [
+                    'input' => ['type' => $domainContentInputName],
+                    'language' => ['type' => 'String', 'defaultValue' => "eng-GB"],
+                    'parentLocationId' => ['type' => 'Int!'],
+                ],
+            ];
+
+        // Domain content input type, no fields
+        $schema[$domainContentInputName] = [
+            'type' => 'input-object',
+            'config' => [
+                'fields' => []
+            ]
+        ];
+    }
+
+    public function canWork(array $schema, array $args)
+    {
+        return
+            isset($args['ContentType']) && $args['ContentType'] instanceof ContentType
+            && !isset($schema[$this->getNameHelper()->domainContentInputName($args['ContentType'])]);
+    }
+}

--- a/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContent.php
+++ b/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContent.php
@@ -40,16 +40,12 @@ class AddFieldDefinitionToDomainContent extends BaseWorker implements SchemaWork
 
         $schema[$domainContentName]['config']['fields'][$fieldDefinitionField] = $this->getDefinition($fieldDefinition);
 
-        $descriptions = $fieldDefinition->getDescriptions();
-        if (isset($descriptions['eng-GB'])) {
-            $fields[$fieldDefinitionField]['description'] = $descriptions['eng-GB'];
-        }
-
         $schema
             [$this->getNameHelper()->domainContentTypeName($args['ContentType'])]
             ['config']['fields']
             [$fieldDefinitionField] = [
                 'type' => $this->getFieldDefinitionType($args['FieldDefinition']),
+                'description' => $fieldDefinition->getDescriptions()['eng-GB'] ?? '',
                 'resolve' => sprintf(
                     '@=value.getFieldDefinition("%s")',
                     $args['FieldDefinition']->identifier

--- a/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContentMutation.php
+++ b/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContentMutation.php
@@ -91,7 +91,7 @@ class AddFieldDefinitionToDomainContentMutation extends BaseWorker implements Sc
             'ezobjectrelation' => 'Int',
             'ezobjectrelationlist' => '[Int]',
             // @todo multi-input format, with type + richtext ?
-            'ezrichtext' => 'String',
+            'ezrichtext' => 'RichTextFieldInput',
             'ezstring' => 'String',
             // @todo might be multiple.
             'ezselection' => 'Int',

--- a/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContentMutation.php
+++ b/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContentMutation.php
@@ -1,0 +1,90 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\FieldDefinition;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\FieldValueBuilder\FieldValueBuilder;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\BaseWorker;
+use BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\SchemaWorker;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+
+class AddFieldDefinitionToDomainContentMutation extends BaseWorker implements SchemaWorker
+{
+    public function work(array &$schema, array $args)
+    {
+        $fieldDefinition = $args['FieldDefinition'];
+        $contentType = $args['ContentType'];
+
+        $fieldDefinitionField = $this->getFieldDefinitionField($fieldDefinition);
+        $domainInputName = $this->getDomainContentInputName($contentType);
+
+        $schema
+            [$domainInputName]
+            ['config']['fields']
+            [$fieldDefinitionField] = [
+                'type' => $this->getFieldDefinitionToGraphQLType($args['FieldDefinition']),
+                'description' => $fieldDefinition->getDescriptions()['eng-GB'] ?? '',
+            ];
+    }
+
+    public function canWork(array $schema, array $args)
+    {
+        return
+            isset($args['FieldDefinition'])
+            && $args['FieldDefinition'] instanceof FieldDefinition
+            & isset($args['ContentType'])
+            && $args['ContentType'] instanceof ContentType
+            && !$this->isFieldDefined($schema, $args);
+    }
+
+    /**
+     * @param ContentType $contentType
+     * @return string
+     */
+    protected function getDomainContentInputName(ContentType $contentType): string
+    {
+        return $this->getNameHelper()->domainContentInputName($contentType);
+    }
+
+    /**
+     * @param FieldDefinition $fieldDefinition
+     * @return string
+     */
+    protected function getFieldDefinitionField(FieldDefinition $fieldDefinition): string
+    {
+        return $this->getNameHelper()->fieldDefinitionField($fieldDefinition);
+    }
+
+    private function isFieldDefined($schema, $args)
+    {
+        return isset(
+            $schema[$this->getNameHelper()->domainContentInputName($args['ContentType'])]
+                   ['config']['fields']
+                   [$this->getFieldDefinitionField($args['FieldDefinition'])]);
+    }
+
+    private function getFieldDefinitionToGraphQLType(FieldDefinition $fieldDefinition)
+    {
+        $map = [
+            'ezauthor' => '[AuthorInput]',
+            'ezbinaryfile' => 'String',
+            'ezboolean' => 'Boolean',
+            'ezcountry' => 'String',
+            'ezmediafile' => 'String',
+            'ezfloat' => 'Float',
+            'ezimage' => 'String',
+            'ezinteger' => 'Int',
+            'ezmedia' => 'String',
+            'ezobjectrelation' => 'Int',
+            'ezobjectrelationlist' => '[Int]',
+            'ezstring' => 'String',
+            'ezselection' => 'Int',
+            'eztext' => 'String',
+        ];
+
+        $requiredFlag = $fieldDefinition->isRequired ? '!': '';
+
+        return isset($map[$fieldDefinition->fieldTypeIdentifier])
+            ? ($map[$fieldDefinition->fieldTypeIdentifier] . $requiredFlag)
+            : ('String' . $requiredFlag);
+    }
+}

--- a/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContentMutation.php
+++ b/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContentMutation.php
@@ -9,40 +9,58 @@ use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 
 class AddFieldDefinitionToDomainContentMutation extends BaseWorker implements SchemaWorker
 {
+    const OPERATION_CREATE = 'create';
+    const OPERATION_UPDATE = 'update';
+
     public function work(array &$schema, array $args)
     {
         $fieldDefinition = $args['FieldDefinition'];
         $contentType = $args['ContentType'];
 
         $fieldDefinitionField = $this->getFieldDefinitionField($fieldDefinition);
-        $domainInputName = $this->getDomainContentInputName($contentType);
 
         $schema
-            [$domainInputName]
+            [$this->getCreateInputName($contentType)]
             ['config']['fields']
             [$fieldDefinitionField] = [
-                'type' => $this->getFieldDefinitionToGraphQLType($args['FieldDefinition']),
+                'type' => $this->getFieldDefinitionToGraphQLType($args['FieldDefinition'], self::OPERATION_CREATE),
+                'description' => $fieldDefinition->getDescriptions()['eng-GB'] ?? '',
+            ];
+
+        $schema
+            [$this->getUpdateInputName($contentType)]
+            ['config']['fields']
+            [$fieldDefinitionField] = [
+                'type' => $this->getFieldDefinitionToGraphQLType($args['FieldDefinition'], self::OPERATION_UPDATE),
                 'description' => $fieldDefinition->getDescriptions()['eng-GB'] ?? '',
             ];
     }
 
-    public function canWork(array $schema, array $args)
+    public function canWork(array $schema, array $args): bool
     {
         return
-            isset($args['FieldDefinition'])
-            && $args['FieldDefinition'] instanceof FieldDefinition
-            & isset($args['ContentType'])
+            isset($args['ContentType'])
             && $args['ContentType'] instanceof ContentType
-            && !$this->isFieldDefined($schema, $args);
+            && isset($args['FieldDefinition'])
+            && $args['FieldDefinition'] instanceof FieldDefinition;
     }
 
     /**
      * @param ContentType $contentType
      * @return string
      */
-    protected function getDomainContentInputName(ContentType $contentType): string
+    protected function getCreateInputName(ContentType $contentType): string
     {
-        return $this->getNameHelper()->domainContentInputName($contentType);
+        return $this->getNameHelper()->domainContentCreateInputName($contentType);
+    }
+
+    /**
+     * @param ContentType $contentType
+     * @return string
+     */
+    private function getUpdateInputName($contentType): string
+    {
+        return $this->getNameHelper()->domainContentUpdateInputName($contentType);
     }
 
     /**
@@ -54,34 +72,35 @@ class AddFieldDefinitionToDomainContentMutation extends BaseWorker implements Sc
         return $this->getNameHelper()->fieldDefinitionField($fieldDefinition);
     }
 
-    private function isFieldDefined($schema, $args)
-    {
-        return isset(
-            $schema[$this->getNameHelper()->domainContentInputName($args['ContentType'])]
-                   ['config']['fields']
-                   [$this->getFieldDefinitionField($args['FieldDefinition'])]);
-    }
-
-    private function getFieldDefinitionToGraphQLType(FieldDefinition $fieldDefinition)
+    private function getFieldDefinitionToGraphQLType(FieldDefinition $fieldDefinition, $operation): string
     {
         $map = [
             'ezauthor' => '[AuthorInput]',
+            // @todo needs custom input for other fields
             'ezbinaryfile' => 'String',
             'ezboolean' => 'Boolean',
+            // @todo might be multiple
             'ezcountry' => 'String',
+            // @todo needs custom input for other fields
             'ezmediafile' => 'String',
             'ezfloat' => 'Float',
+            // @todo needs custom input for other fields
             'ezimage' => 'String',
             'ezinteger' => 'Int',
             'ezmedia' => 'String',
             'ezobjectrelation' => 'Int',
             'ezobjectrelationlist' => '[Int]',
+            // @todo multi-input format, with type + richtext ?
+            'ezrichtext' => 'String',
             'ezstring' => 'String',
+            // @todo might be multiple.
             'ezselection' => 'Int',
             'eztext' => 'String',
+            // @todo externalize to package
+            'query' => null
         ];
 
-        $requiredFlag = $fieldDefinition->isRequired ? '!': '';
+        $requiredFlag = $operation == self::OPERATION_CREATE && $fieldDefinition->isRequired ? '!': '';
 
         return isset($map[$fieldDefinition->fieldTypeIdentifier])
             ? ($map[$fieldDefinition->fieldTypeIdentifier] . $requiredFlag)

--- a/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContentMutation.php
+++ b/DomainContent/SchemaWorker/FieldDefinition/AddFieldDefinitionToDomainContentMutation.php
@@ -85,7 +85,7 @@ class AddFieldDefinitionToDomainContentMutation extends BaseWorker implements Sc
             'ezmediafile' => 'String',
             'ezfloat' => 'Float',
             // @todo needs custom input for other fields
-            'ezimage' => 'String',
+            'ezimage' => 'ImageFieldInput',
             'ezinteger' => 'Int',
             'ezmedia' => 'String',
             'ezobjectrelation' => 'Int',

--- a/Exception/UnsupportedFieldTypeException.php
+++ b/Exception/UnsupportedFieldTypeException.php
@@ -1,0 +1,14 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\Exception;
+
+use InvalidArgumentException;
+
+class UnsupportedFieldTypeException extends InvalidArgumentException
+{
+    public function __construct($fieldType, $operation)
+    {
+        parent::__construct(
+            "The $fieldType field type is not supported for $operation"
+        );
+    }
+}

--- a/GraphQL/Mutation/UploadFiles.php
+++ b/GraphQL/Mutation/UploadFiles.php
@@ -1,0 +1,112 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\GraphQL\Mutation;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\FieldType;
+use EzSystems\EzPlatformAdminUi\UI\Config\Provider\ContentTypeMappings;
+use GraphQL\Error\UserError;
+use Overblog\GraphQLBundle\Definition\Argument;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class UploadFiles
+{
+    /**
+     * @var ContentTypeMappings
+     */
+    private $contentTypeMappings;
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    public function __construct(Repository $repository, ContentTypeMappings $contentTypeMappings)
+    {
+        $this->repository = $repository;
+        $this->contentTypeMappings = $contentTypeMappings;
+    }
+
+    public function uploadFiles(Argument $args)
+    {
+        $createdContent = [];
+        $warnings = [];
+
+        foreach ($args['files'] as $file) {
+            if (!$file instanceof UploadedFile) {
+                continue;
+            }
+
+            $mimeType = $file->getMimeType();
+            $mapping = $this->mapAgainstConfig($mimeType);
+
+            try {
+                $createdContent[] = $this->createContent($mapping, $file, $args['locationId']);
+            } catch (\Exception $e) {
+                $warnings[] = $e->getMessage();
+            }
+        }
+
+        return ['files' => $createdContent, 'warnings' =>$warnings];
+    }
+
+    private function mapAgainstConfig($mimeType)
+    {
+        foreach ($this->contentTypeMappings->getConfig()['defaultMappings'] as $mapping) {
+            if (in_array($mimeType, $mapping['mimeTypes'])) {
+                return array_filter(
+                    $mapping,
+                    function($key) {
+                        return in_array($key, ['contentTypeIdentifier', 'contentFieldIdentifier', 'nameFieldIdentifier']);
+                    },
+                    ARRAY_FILTER_USE_KEY
+                );
+            }
+        }
+
+        return $this->contentTypeMappings->getConfig()['fallbackContentType'];
+    }
+
+    /**
+     * @return ContentInfo
+     */
+    private function createContent(array $mapping, UploadedFile $file, $locationId): ContentInfo
+    {
+        $contentService = $this->repository->getContentService();
+        $locationService = $this->repository->getLocationService();
+
+        $contentType = $this->repository->getContentTypeService()->loadContentTypeByIdentifier($mapping['contentTypeIdentifier']);
+        // @todo use parameter for language
+        $struct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+        $struct->setField($mapping['nameFieldIdentifier'], $file->getClientOriginalName());
+
+        // @todo The type of value that is used depends on contentFieldIdentifier's type
+        $fieldDefinition = $contentType->getFieldDefinition($mapping['contentFieldIdentifier']);
+        switch ($fieldDefinition->fieldTypeIdentifier)
+        {
+            case 'ezimage':
+                $valueType = FieldType\Image\Value::class;
+                break;
+            case 'ezbinaryfile':
+                $valueType = FieldType\BinaryFile\Value::class;
+                break;
+            case 'ezmedia':
+                $valueType = FieldType\Media\Value::class;
+                break;
+            default:
+                throw new UserError("FieldType not supported for upload");
+        }
+        $struct->setField(
+            $mapping['contentFieldIdentifier'],
+            new $valueType([
+                'fileName' => $file->getClientOriginalName(),
+                'inputUri' => $file->getPathname(),
+                'fileSize' => $file->getSize(),
+            ])
+        );
+
+        $draft = $contentService->createContent($struct, [$locationService->newLocationCreateStruct($locationId)]);
+        $content = $contentService->publishVersion($draft->getVersionInfo());
+
+        return $content->contentInfo;
+    }
+}

--- a/GraphQL/Resolver/DomainContentResolver.php
+++ b/GraphQL/Resolver/DomainContentResolver.php
@@ -391,6 +391,20 @@ HTML5EDIT;
                 $dom->loadXML($input);
                 $docbook = $this->richTextConverter->convert($dom);
                 $fieldValue = new FieldType\RichText\Value($docbook);
+            } elseif ($format === 'markdown') {
+                $parseDown = new \Parsedown();
+                $html = $parseDown->text($input);
+                $input = <<<HTML5EDIT
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">$html</section>
+HTML5EDIT;
+                $dom = new \DOMDocument();
+                $dom->loadXML($input);
+                $docbook = $this->richTextConverter->convert($dom);
+                $fieldValue = new FieldType\RichText\Value($docbook);
+            } elseif ($format === 'docbook') {
+                $fieldValue = new FieldType\RichText\Value($input);
+            } else {
+                throw new UserError("Unsupported richtext input format $format");
             }
         } else {
             $fieldValue = $input[$fieldDefinition->identifier];

--- a/GraphQL/Resolver/Map/UploadMap.php
+++ b/GraphQL/Resolver/Map/UploadMap.php
@@ -9,7 +9,7 @@ class UploadMap extends ResolverMap
     protected function map()
     {
         return [
-            'ImageUpload' => [self::SCALAR_TYPE => function () { return new GraphQLUploadType(); }],
+            'FileUpload' => [self::SCALAR_TYPE => function () { return new GraphQLUploadType(); }],
         ];
     }
 }

--- a/GraphQL/Resolver/Map/UploadMap.php
+++ b/GraphQL/Resolver/Map/UploadMap.php
@@ -1,0 +1,15 @@
+<?php
+namespace BD\EzPlatformGraphQLBundle\GraphQL\Resolver\Map;
+
+use Overblog\GraphQLBundle\Resolver\ResolverMap;
+use Overblog\GraphQLBundle\Upload\Type\GraphQLUploadType;
+
+class UploadMap extends ResolverMap
+{
+    protected function map()
+    {
+        return [
+            'ImageUpload' => [self::SCALAR_TYPE => function () { return new GraphQLUploadType(); }],
+        ];
+    }
+}

--- a/Resources/config/domain_content.yml
+++ b/Resources/config/domain_content.yml
@@ -17,29 +17,14 @@ services:
             tags:
                 - {name: 'ezplatform_graphql.schema_builder'}
 
-    BD\EzPlatformGraphQLBundle\DomainContent\DomainContentSchemaBuilder: ~
+    BD\EzPlatformGraphQLBundle\DomainContent\:
+        resource: '../../DomainContent/'
 
     BD\EzPlatformGraphQLBundle\Schema\SchemaGenerator: ~
-
-    BD\EzPlatformGraphQLBundle\DomainContent\RepositoryDomainGenerator:
-
-    BD\EzPlatformGraphQLBundle\DomainContent\NameHelper: ~
-
-    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType\DefineDomainContent: ~
-
-    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType\AddDomainContentToDomainGroup: ~
-
-    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentTypeGroup\DefineDomainGroup: ~
-
-    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentTypeGroup\AddDomainGroupToDomain: ~
-
-    BD\EzPlatformGraphQLBundle\DomainContent\FieldValueBuilder\BaseFieldValueBuilder: ~
 
     BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\FieldDefinition\AddFieldDefinitionToDomainContent:
         arguments:
             $defaultFieldValueBuilder: '@BD\EzPlatformGraphQLBundle\DomainContent\FieldValueBuilder\BaseFieldValueBuilder'
-
-    BD\EzPlatformGraphQLBundle\DomainContent\SchemaWorker\ContentType\AddContentTypeToContentTypeIdentifierList: ~
 
     BD\EzPlatformGraphQLBundle\DomainContent\FieldValueBuilder\RelationListFieldValueBuilder:
         tags:

--- a/Resources/config/graphql/FieldValueInput.types.yml
+++ b/Resources/config/graphql/FieldValueInput.types.yml
@@ -1,0 +1,10 @@
+AuthorInput:
+    type: input-object
+    config:
+        fields:
+            id:
+                type: "Int"
+            name:
+                type: "String"
+            email:
+                type: "String"

--- a/Resources/config/graphql/PlatformMutation.types.yml
+++ b/Resources/config/graphql/PlatformMutation.types.yml
@@ -63,6 +63,13 @@ RichTextFieldInput:
     config:
         fields:
             format:
-                type: String
+                type: RichTextFieldInputFormat
             input:
                 type: String
+
+RichTextFieldInputFormat:
+    type: enum
+    config:
+        values:
+            markdown: {}
+            html: {}

--- a/Resources/config/graphql/PlatformMutation.types.yml
+++ b/Resources/config/graphql/PlatformMutation.types.yml
@@ -39,3 +39,12 @@ ImageUpload:
     type: custom-scalar
     config:
         scalarType: '@=newObject("Overblog\\GraphQLBundle\\Upload\\Type\\GraphQLUploadType")'
+
+RichTextFieldInput:
+    type: input-object
+    config:
+        fields:
+            format:
+                type: String
+            input:
+                type: String

--- a/Resources/config/graphql/PlatformMutation.types.yml
+++ b/Resources/config/graphql/PlatformMutation.types.yml
@@ -23,3 +23,19 @@ DeleteContentPayload:
             id:
                 type: ID
                 description: "Global ID"
+
+ImageFieldInput:
+    type: input-object
+    config:
+        fields:
+            name:
+                type: String
+            alternativeText:
+                type: String
+            file:
+                type: ImageUpload
+
+ImageUpload:
+    type: custom-scalar
+    config:
+        scalarType: '@=newObject("Overblog\\GraphQLBundle\\Upload\\Type\\GraphQLUploadType")'

--- a/Resources/config/graphql/PlatformMutation.types.yml
+++ b/Resources/config/graphql/PlatformMutation.types.yml
@@ -12,6 +12,24 @@ PlatformMutation:
                     contentId:
                         type: Int
                         description: "ID of the content item to delete"
+            uploadFiles:
+                type: UploadedFilesPayload
+                resolve: '@=mutation("UploadFiles", [args])'
+                args:
+                    locationId:
+                        type: Int!
+                        description: "The location ID of a container to upload the files to"
+                    files:
+                        type: "[ImageUpload]!"
+
+UploadedFilesPayload:
+    type: object
+    config:
+        fields:
+            files:
+                type: "[DomainContent]"
+            warnings:
+                type: "[String]"
 
 DeleteContentPayload:
     type: object

--- a/Resources/config/graphql/PlatformMutation.types.yml
+++ b/Resources/config/graphql/PlatformMutation.types.yml
@@ -2,44 +2,24 @@ PlatformMutation:
     type: object
     config:
         fields:
-            createSection:
-                builder: Mutation
-                builderConfig:
-                    inputType: createSectionInput
-                    payloadType: sectionPayload
-                    mutateAndGetPayload: "@=mutation('CreateSection', [value])"
-            deleteSection:
-                builder: Mutation
-                builderConfig:
-                    inputType: deleteSectionInput
-                    payloadType: sectionPayload
-                    mutateAndGetPayload: "@=mutation('DeleteSection', [value])"
+            deleteContent:
+                type: DeleteContentPayload
+                resolve: '@=mutation("DeleteDomainContent", [args])'
+                args:
+                    id:
+                        type: ID
+                        description: "Global ID of the content item to delete"
+                    contentId:
+                        type: Int
+                        description: "ID of the content item to delete"
 
-createSectionInput:
-    type: relay-mutation-input
+DeleteContentPayload:
+    type: object
     config:
         fields:
-            identifier:
-                type: "String"
-            name:
-                type: "String"
-
-deleteSectionInput:
-    type: relay-mutation-input
-    config:
-        fields:
+            contentId:
+                type: Int
+                description: "Numerical content id"
             id:
-                type: "Int"
-            identifier:
-                type: "String"
-
-sectionPayload:
-    type: relay-mutation-payload
-    config:
-        fields:
-            id:
-                type: "Int"
-            identifier:
-                type: "String"
-            name:
-                type: "String"
+                type: ID
+                description: "Global ID"

--- a/Resources/config/graphql/PlatformMutation.types.yml
+++ b/Resources/config/graphql/PlatformMutation.types.yml
@@ -20,7 +20,7 @@ PlatformMutation:
                         type: Int!
                         description: "The location ID of a container to upload the files to"
                     files:
-                        type: "[ImageUpload]!"
+                        type: "[FileUpload]!"
 
 UploadedFilesPayload:
     type: object
@@ -51,9 +51,9 @@ ImageFieldInput:
             alternativeText:
                 type: String
             file:
-                type: ImageUpload
+                type: FileUpload
 
-ImageUpload:
+FileUpload:
     type: custom-scalar
     config:
         scalarType: '@=newObject("Overblog\\GraphQLBundle\\Upload\\Type\\GraphQLUploadType")'

--- a/Resources/config/resolvers.yml
+++ b/Resources/config/resolvers.yml
@@ -47,6 +47,7 @@ services:
             - { name: overblog_graphql.resolver, alias: "ContentName", method: "resolveContentName" }
             - { name: overblog_graphql.resolver, alias: "MainUrlAlias", method: "resolveMainUrlAlias" }
             - { name: overblog_graphql.mutation, alias: "CreateDomainContent", method: "createDomainContent" }
+            - { name: overblog_graphql.mutation, alias: "DeleteDomainContent", method: "deleteDomainContent" }
         arguments:
             $repository: "@ezpublish.siteaccessaware.repository"
 

--- a/Resources/config/resolvers.yml
+++ b/Resources/config/resolvers.yml
@@ -51,6 +51,7 @@ services:
             - { name: overblog_graphql.mutation, alias: "UpdateDomainContent", method: "updateDomainContent" }
         arguments:
             $repository: "@ezpublish.siteaccessaware.repository"
+            $richTextConverter: '@ezpublish.fieldType.ezrichtext.converter.input.xhtml5'
 
     BD\EzPlatformGraphQLBundle\GraphQL\Resolver\UserResolver:
         tags:

--- a/Resources/config/resolvers.yml
+++ b/Resources/config/resolvers.yml
@@ -46,6 +46,7 @@ services:
             - { name: overblog_graphql.resolver, alias: "DomainRelationFieldValue", method: "resolveDomainRelationFieldValue" }
             - { name: overblog_graphql.resolver, alias: "ContentName", method: "resolveContentName" }
             - { name: overblog_graphql.resolver, alias: "MainUrlAlias", method: "resolveMainUrlAlias" }
+            - { name: overblog_graphql.mutation, alias: "CreateDomainContent", method: "createDomainContent" }
         arguments:
             $repository: "@ezpublish.siteaccessaware.repository"
 

--- a/Resources/config/resolvers.yml
+++ b/Resources/config/resolvers.yml
@@ -127,3 +127,5 @@ services:
     BD\EzPlatformGraphQLBundle\GraphQL\Resolver\SelectionFieldResolver:
         tags:
             - { name: overblog_graphql.resolver, alias: "SelectionFieldValue", method: "resolveSelectionFieldValue"}
+
+    BD\EzPlatformGraphQLBundle\GraphQL\Resolver\Map\UploadMap: ~

--- a/Resources/config/resolvers.yml
+++ b/Resources/config/resolvers.yml
@@ -53,6 +53,12 @@ services:
             $repository: "@ezpublish.siteaccessaware.repository"
             $richTextConverter: '@ezpublish.fieldType.ezrichtext.converter.input.xhtml5'
 
+    BD\EzPlatformGraphQLBundle\GraphQL\Mutation\UploadFiles:
+        arguments:
+            $repository: '@ezpublish.siteaccessaware.repository'
+        tags:
+            - { name: overblog_graphql.mutation, alias: "UploadFiles", method: "uploadFiles" }
+
     BD\EzPlatformGraphQLBundle\GraphQL\Resolver\UserResolver:
         tags:
             - { name: overblog_graphql.resolver, alias: "User", method: "resolveUser" }

--- a/Resources/config/resolvers.yml
+++ b/Resources/config/resolvers.yml
@@ -48,6 +48,7 @@ services:
             - { name: overblog_graphql.resolver, alias: "MainUrlAlias", method: "resolveMainUrlAlias" }
             - { name: overblog_graphql.mutation, alias: "CreateDomainContent", method: "createDomainContent" }
             - { name: overblog_graphql.mutation, alias: "DeleteDomainContent", method: "deleteDomainContent" }
+            - { name: overblog_graphql.mutation, alias: "UpdateDomainContent", method: "updateDomainContent" }
         arguments:
             $repository: "@ezpublish.siteaccessaware.repository"
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "ezsystems/ezpublish-kernel": "^6.0|^7.0",
-        "overblog/graphql-bundle": "^0.11"
+        "overblog/graphql-bundle": "^0.11",
+        "erusev/parsedown": "^1.0"
     },
     "require-dev": {
         "overblog/graphiql-bundle": "^0.1"

--- a/doc/research/content_mutations.md
+++ b/doc/research/content_mutations.md
@@ -1,16 +1,23 @@
 Crude schema that allows to create a blog post:
 
-```
+```yaml
+# src/AppBundle/Resources/config/graphql/DomainContentMutation.types.yml:
 DomainContentMutation:
     type: object
     config:
         fields:
             createBlogPost:
                 type: BlogPostContent!
-                resolve: "@=mutation('CreateDomainContent', [args['input'], 'blog_post'])"
+                resolve: "@=mutation('CreateDomainContent', [args['input'], 'blog_post', args['parentLocationId'], args['language']])"
+                # @todo use args builder ?
                 args:
                     input:
                         type: BlogPostContentInput!
+                    language:
+                        type: String
+                        defaultValue: "eng-GB"
+                    parentLocationId:
+                        type: Int!
 
 BlogPostContentPayload:
     type: object
@@ -34,9 +41,9 @@ BlogPostContentInput:
             #publicationDate:
             #    type: GenericFieldValue
             #    resolve: '@=resolver("DomainFieldValue", [value, "publication_date"])'
-            #author:
-            #    type: '[AuthorFieldValue]'
-            #    resolve: '@=resolver("DomainFieldValue", [value, "author"]).authors'
+            author:
+                type: '[AuthorInput]'
+            #    resolve: '@=resolver("AuthorFieldInput", [value])'
             #authorsPosition:
             #    type: String
             #    resolve: '@=resolver("DomainFieldValue", [value, "authors_position"])'

--- a/doc/research/content_mutations.md
+++ b/doc/research/content_mutations.md
@@ -1,3 +1,16 @@
+Uploading a file with curl:
+
+```
+curl -v -X POST \
+  http://localhost:8000/graphql \
+  -H 'Cookie: eZSESSID98defd6ee70dfb1dea416cecdf391f58=cdkln1g0q8bhuc3mreu7nhaq3d' \
+  -F 'operations={"query":"mutation CreateImage($name: String!, $alternativeText: String!, $file: ImageUpload!) { createImage( parentLocationId: 51, input: { name: $name, image: {alternativeText: $alternativeText, file: $file} } ) { _info { id mainLocationId } name image { fileName alternativeText uri } } }","variables":{"file": null, "name": "2nd image upload", "alternativeText": "With generated schema"}}' \
+  -F 'map={"0":["variables.file"]}' \
+  -F "0"=@/Users/bdunogier/Desktop/screenshot.png
+```
+
+See https://github.com/jaydenseric/graphql-multipart-request-spec#file-list for multiple files.
+
 Crude schema that allows to create a blog post:
 
 ```yaml

--- a/doc/research/content_mutations.md
+++ b/doc/research/content_mutations.md
@@ -1,0 +1,49 @@
+Crude schema that allows to create a blog post:
+
+```
+DomainContentMutation:
+    type: object
+    config:
+        fields:
+            createBlogPost:
+                type: BlogPostContent!
+                resolve: "@=mutation('CreateDomainContent', [args['input'], 'blog_post'])"
+                args:
+                    input:
+                        type: BlogPostContentInput!
+
+BlogPostContentPayload:
+    type: object
+    config:
+        fields:
+            item:
+                type: BlogPostContent
+
+BlogPostContentInput:
+    type: input-object
+    config:
+        fields:
+            title:
+                type: String!
+            intro:
+                type: String
+            body:
+                type: String
+            #image:
+            #    type:
+            #publicationDate:
+            #    type: GenericFieldValue
+            #    resolve: '@=resolver("DomainFieldValue", [value, "publication_date"])'
+            #author:
+            #    type: '[AuthorFieldValue]'
+            #    resolve: '@=resolver("DomainFieldValue", [value, "author"]).authors'
+            #authorsPosition:
+            #    type: String
+            #    resolve: '@=resolver("DomainFieldValue", [value, "authors_position"])'
+            #tags:
+            #    type: GenericFieldValue
+            #    resolve: '@=resolver("DomainFieldValue", [value, "tags"])'
+            #metas:
+            #    type: GenericFieldValue
+            #    resolve: '@=resolver("DomainFieldValue", [value, "metas"])'
+```

--- a/doc/research/content_mutations.md
+++ b/doc/research/content_mutations.md
@@ -54,3 +54,20 @@ BlogPostContentInput:
             #    type: GenericFieldValue
             #    resolve: '@=resolver("DomainFieldValue", [value, "metas"])'
 ```
+
+Update domain content mutation:
+```
+DomainContentMutation:
+    config:
+        fields:
+            # @todo Generate
+            updateBlogPost:
+                type: BlogPostContent!
+                resolve: '@=mutation("UpdateDomainContent", [args["input"], "blog_post", args["id"], args["versionNo"]])'
+                args:
+                    id:  { type: ID, description: "ID of the content item to update" }
+                    contentId:  { type: Int, description: "ID of the content item to update" }
+                    versionNo: { type: Int, description: "Optional version number to update. If it is a draft, it is saved, not published. If it is archived, it is used as the source version for the update, to complete missing fields."}
+                    input: { type: BlogPostContentInput }
+                    language: { type: String, defaultValue: eng-GB }
+```


### PR DESCRIPTION
Adds support for creating, updating and deleting content over GraphQL.

For each content type:
- two mutations are defined `create{ContentType}` (`createBlogPost`, `createImage`, ...) and `update{ContentType}` (`updatePlace`, `updateVideo`, ...)
- two input types are defined, one for each operation: `updateArticleInput`, `createImageInput`

Usage:
```
mutation CreateMyBlogPost
{
  createBlogPost(
    parentLocationId: 216,
    input: {
      title: "The post's title",
      author: [
        {name: "Bertrand Dunogier", email: "noemail@ez.no"}
      ],
      body: {
        format: html,
        input: "<h1>title</h1><p>paragraph</p>"
      }
    } 
  ) {
    _info { id mainLocationId }
    title
    body { html5 }
  }
}
```